### PR TITLE
Bump Z3 version to 4.8.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN    apt-get update            \
 
 RUN pip3 install virtualenv
 
-RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.11 \
+RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && cd z3                                                         \
     && python scripts/mk_make.py                                     \
     && cd build                                                      \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,6 @@ Follow the instructions in the [README file](https://github.com/runtimeverificat
 
 ### Dependencies
 
-Note that KEVM requires version 4.8.11 of the Z3 solver to be installed; follow
+Note that KEVM requires version 4.8.15 of the Z3 solver to be installed; follow
 the instructions in the [README
 file](https://github.com/runtimeverification/evm-semantics) to do so.

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ The following are needed for building/running KEVM:
 -   GNU [Bison](https://www.gnu.org/software/bison/), [Flex](https://github.com/westes/flex), and [Autoconf](http://www.gnu.org/software/autoconf/).
 -   GNU [libmpfr](https://www.mpfr.org/) and [libtool](https://www.gnu.org/software/libtool/).
 -   Java 8 JDK (eg. [OpenJDK](http://openjdk.java.net/))
--   [Z3](https://github.com/Z3Prover/z3) version 4.8.11
+-   [Z3](https://github.com/Z3Prover/z3) version 4.8.15
 
 For the exact dependencies check the Dockerfile.
 
 #### Installing Z3
 
-KEVM requires Z3 version 4.8.11, which you may need to install from a source
+KEVM requires Z3 version 4.8.15, which you may need to install from a source
 build if your package manager supplies a different version. To do so, follow the
 instructions
 [here](https://github.com/Z3Prover/z3#building-z3-using-make-and-gccclang) after
@@ -66,7 +66,7 @@ checking out the correct tag in the Z3 repository:
 ```sh
 git clone https://github.com/Z3Prover/z3.git
 cd z3
-git checkout z3-4.8.11
+git checkout z3-4.8.15
 python scripts/mk_make.py
 cd build
 make


### PR DESCRIPTION
This PR reflects a pending change in the upstream K distribution; it updates package files and documentation to reflect the new version of Z3 we require.