### PR TITLE
Switch --directory => --definition flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@
 /tests/gen-spec/*.out
 /tests/gen-spec/*.sol
 /tests/specs/**/*-bin-runtime.k
+/tests/specs/**/haskell
+/tests/specs/**/java
 /tests/specs/opcodes/evm-optimizations-spec.md
 /tests/specs/**/*.prove.out
 /tests/specs/**/*.sol.json

--- a/Makefile
+++ b/Makefile
@@ -445,12 +445,12 @@ tests/specs/examples/erc721-bin-runtime.k: tests/specs/examples/ERC721.sol $(KEV
 tests/specs/examples/empty-bin-runtime.k: tests/specs/examples/Empty.sol $(KEVM_LIB)/$(haskell_kompiled) kevm-pyk-venv
 	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< Empty > $@
 
-tests/gen-spec/mcd-spec.k.check: tests/gen-spec/timestamp kevm-pyk-venv
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) gen-spec tests/gen-spec MCD-SPEC > $@.out
+tests/gen-spec/mcd-spec.k.check: tests/gen-spec/kompiled/timestamp kevm-pyk-venv
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) gen-spec MCD-SPEC --definition tests/gen-spec/kompiled > $@.out
 	$(CHECK) $@.out $@.expected
 
-tests/gen-spec/timestamp: tests/gen-spec/verification.k
-	$(KOMPILE) --backend haskell --definition tests/gen-spec $< --main-module MCD-VERIFICATION
+tests/gen-spec/kompiled/timestamp: tests/gen-spec/verification.k
+	$(KOMPILE) --backend haskell --definition tests/gen-spec/kompiled $< --main-module MCD-VERIFICATION
 
 
 .SECONDEXPANSION:

--- a/Makefile
+++ b/Makefile
@@ -451,20 +451,20 @@ tests/gen-spec/mcd-spec.k.check: tests/gen-spec/verification-kompiled/timestamp 
 	$(CHECK) $@.out $@.expected
 
 tests/gen-spec/verification-kompiled/timestamp: tests/gen-spec/verification.k
-	$(KOMPILE) --backend haskell --directory tests/gen-spec $< --main-module MCD-VERIFICATION
+	$(KOMPILE) --backend haskell --definition tests/gen-spec/verification-kompiled $< --main-module MCD-VERIFICATION
 
 
 .SECONDEXPANSION:
 tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/$$(KPROVE_FILE)-kompiled/timestamp
 	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS) \
-	    --directory tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
+	    --definition tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
 tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
-	$(KOMPILE) --backend $(word 3, $(subst /, , $*)) $<                                                 \
-	    --directory tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(word 3, $(subst /, , $*)) \
-	    --main-module $(KPROVE_MODULE)                                                                  \
-	    --syntax-module $(KPROVE_MODULE)                                                                \
-	    --concrete-rules-file tests/specs/$(firstword $(subst /, ,$*))/concrete-rules.txt               \
+	$(KOMPILE) --backend $(word 3, $(subst /, , $*)) $<                                                  \
+	    --definition tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(word 3, $(subst /, , $*)) \
+	    --main-module $(KPROVE_MODULE)                                                                   \
+	    --syntax-module $(KPROVE_MODULE)                                                                 \
+	    --concrete-rules-file tests/specs/$(firstword $(subst /, ,$*))/concrete-rules.txt                \
 	    $(KOMPILE_OPTS)
 
 tests/%.search: tests/%

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ haskell_main_module    := EDSL
 haskell_syntax_module  := $(haskell_main_module)
 haskell_main_file      := edsl.md
 haskell_main_filename  := $(basename $(notdir $(haskell_main_file)))
-haskell_kompiled_dir   := $(haskell_dir)/$(haskell_main_filename)-kompiled
+haskell_kompiled_dir   := $(haskell_dir)
 haskell_kompiled       := $(haskell_kompiled_dir)/definition.kore
 
 ifeq ($(UNAME_S),Darwin)
@@ -240,7 +240,7 @@ llvm_main_module   := ETHEREUM-SIMULATION
 llvm_syntax_module := $(llvm_main_module)
 llvm_main_file     := driver.md
 llvm_main_filename := $(basename $(notdir $(llvm_main_file)))
-llvm_kompiled      := $(llvm_dir)/$(llvm_main_filename)-kompiled/interpreter
+llvm_kompiled      := $(llvm_dir)/interpreter
 
 ifeq ($(UNAME_S),Darwin)
 $(KEVM_LIB)/$(llvm_kompiled): $(libcryptopp_out)
@@ -260,7 +260,7 @@ node_main_module   := EVM-NODE
 node_syntax_module := $(node_main_module)
 node_main_file     := evm-node.md
 node_main_filename := $(basename $(notdir $(node_main_file)))
-node_kore          := $(node_dir)/$(node_main_filename)-kompiled/definition.kore
+node_kore          := $(node_dir)/definition.kore
 node_kompiled      := $(node_dir)/build/kevm-vm
 export node_dir
 export node_main_filename
@@ -435,31 +435,31 @@ tests/%.prove-legacy: tests/%
 kevm-pyk-venv:
 	$(MAKE) -C ./kevm_pyk venv-prod
 
-tests/specs/examples/erc20-spec/haskell/erc20-spec-kompiled/timestamp: tests/specs/examples/erc20-bin-runtime.k
+tests/specs/examples/erc20-spec/haskell/timestamp: tests/specs/examples/erc20-bin-runtime.k
 tests/specs/examples/erc20-bin-runtime.k: tests/specs/examples/ERC20.sol $(KEVM_LIB)/$(haskell_kompiled) kevm-pyk-venv
 	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< ERC20 > $@
 
-tests/specs/examples/erc721-spec/haskell/erc721-spec-kompiled/timestamp: tests/specs/examples/erc721-bin-runtime.k
+tests/specs/examples/erc721-spec/haskell/timestamp: tests/specs/examples/erc721-bin-runtime.k
 tests/specs/examples/erc721-bin-runtime.k: tests/specs/examples/ERC721.sol $(KEVM_LIB)/$(haskell_kompiled) kevm-pyk-venv
 	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< ERC721 > $@
 
 tests/specs/examples/empty-bin-runtime.k: tests/specs/examples/Empty.sol $(KEVM_LIB)/$(haskell_kompiled) kevm-pyk-venv
 	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< Empty > $@
 
-tests/gen-spec/mcd-spec.k.check: tests/gen-spec/verification-kompiled/timestamp kevm-pyk-venv
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) gen-spec tests/gen-spec/verification-kompiled MCD-SPEC > $@.out
+tests/gen-spec/mcd-spec.k.check: tests/gen-spec/timestamp kevm-pyk-venv
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) gen-spec tests/gen-spec MCD-SPEC > $@.out
 	$(CHECK) $@.out $@.expected
 
-tests/gen-spec/verification-kompiled/timestamp: tests/gen-spec/verification.k
-	$(KOMPILE) --backend haskell --definition tests/gen-spec/verification-kompiled $< --main-module MCD-VERIFICATION
+tests/gen-spec/timestamp: tests/gen-spec/verification.k
+	$(KOMPILE) --backend haskell --definition tests/gen-spec $< --main-module MCD-VERIFICATION
 
 
 .SECONDEXPANSION:
-tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/$$(KPROVE_FILE)-kompiled/timestamp
+tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/timestamp
 	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS) \
 	    --definition tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
-tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
+tests/specs/%/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
 	$(KOMPILE) --backend $(word 3, $(subst /, , $*)) $<                                                  \
 	    --definition tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(word 3, $(subst /, , $*)) \
 	    --main-module $(KPROVE_MODULE)                                                                   \
@@ -528,36 +528,36 @@ prove_mcd_tests          := $(filter-out $(prove_skip_tests), $(wildcard $(prove
 prove_optimization_tests := $(filter-out $(prove_skip_tests), tests/specs/opcodes/evm-optimizations-spec.md)
 
 ## best-effort list of provex kompiled definitions to produce ahead of time
-provex_definitions :=                                                                                              \
-                      tests/specs/benchmarks/functional-spec/haskell/functional-spec-kompiled/timestamp            \
-                      tests/specs/benchmarks/functional-spec/java/functional-spec-kompiled/timestamp               \
-                      tests/specs/benchmarks/verification/haskell/verification-kompiled/timestamp                  \
-                      tests/specs/benchmarks/verification/java/verification-kompiled/timestamp                     \
-                      tests/specs/bihu/functional-spec/haskell/functional-spec-kompiled/timestamp                  \
-                      tests/specs/bihu/functional-spec/java/functional-spec-kompiled/timestamp                     \
-                      tests/specs/bihu/verification/haskell/verification-kompiled/timestamp                        \
-                      tests/specs/bihu/verification/java/verification-kompiled/timestamp                           \
-                      tests/specs/erc20/verification/haskell/verification-kompiled/timestamp                       \
-                      tests/specs/erc20/verification/java/verification-kompiled/timestamp                          \
-                      tests/specs/examples/erc20-spec/haskell/erc20-spec-kompiled/timestamp                        \
-                      tests/specs/examples/erc721-spec/haskell/erc721-spec-kompiled/timestamp                      \
-                      tests/specs/examples/solidity-code-spec/haskell/solidity-code-spec-kompiled/timestamp        \
-                      tests/specs/examples/solidity-code-spec/java/solidity-code-spec-kompiled/timestamp           \
-                      tests/specs/examples/sum-to-n-spec/haskell/sum-to-n-spec-kompiled/timestamp                  \
-                      tests/specs/examples/sum-to-n-spec/java/sum-to-n-spec-kompiled/timestamp                     \
-                      tests/specs/functional/infinite-gas-spec/haskell/infinite-gas-spec-kompiled/timestamp        \
-                      tests/specs/functional/lemmas-no-smt-spec/haskell/lemmas-no-smt-spec-kompiled/timestamp      \
-                      tests/specs/functional/lemmas-no-smt-spec/java/lemmas-no-smt-spec-kompiled/timestamp         \
-                      tests/specs/functional/lemmas-spec/haskell/lemmas-spec-kompiled/timestamp                    \
-                      tests/specs/functional/lemmas-spec/java/lemmas-spec-kompiled/timestamp                       \
-                      tests/specs/functional/merkle-spec/haskell/merkle-spec-kompiled/timestamp                    \
-                      tests/specs/functional/storageRoot-spec/haskell/storageRoot-spec-kompiled/timestamp          \
-                      tests/specs/mcd/functional-spec/haskell/functional-spec-kompiled/timestamp                   \
-                      tests/specs/mcd/functional-spec/java/functional-spec-kompiled/timestamp                      \
-                      tests/specs/mcd/verification/haskell/verification-kompiled/timestamp                         \
-                      tests/specs/mcd/verification/java/verification-kompiled/timestamp                            \
-                      tests/specs/opcodes/evm-optimizations-spec/haskell/evm-optimizations-spec-kompiled/timestamp \
-                      tests/specs/opcodes/verification/java/verification-kompiled/timestamp
+provex_definitions :=                                                              \
+                      tests/specs/benchmarks/functional-spec/haskell/timestamp     \
+                      tests/specs/benchmarks/functional-spec/java/timestamp        \
+                      tests/specs/benchmarks/verification/haskell/timestamp        \
+                      tests/specs/benchmarks/verification/java/timestamp           \
+                      tests/specs/bihu/functional-spec/haskell/timestamp           \
+                      tests/specs/bihu/functional-spec/java/timestamp              \
+                      tests/specs/bihu/verification/haskell/timestamp              \
+                      tests/specs/bihu/verification/java/timestamp                 \
+                      tests/specs/erc20/verification/haskell/timestamp             \
+                      tests/specs/erc20/verification/java/timestamp                \
+                      tests/specs/examples/erc20-spec/haskell/timestamp            \
+                      tests/specs/examples/erc721-spec/haskell/timestamp           \
+                      tests/specs/examples/solidity-code-spec/haskell/timestamp    \
+                      tests/specs/examples/solidity-code-spec/java/timestamp       \
+                      tests/specs/examples/sum-to-n-spec/haskell/timestamp         \
+                      tests/specs/examples/sum-to-n-spec/java/timestamp            \
+                      tests/specs/functional/infinite-gas-spec/haskell/timestamp   \
+                      tests/specs/functional/lemmas-no-smt-spec/haskell/timestamp  \
+                      tests/specs/functional/lemmas-no-smt-spec/java/timestamp     \
+                      tests/specs/functional/lemmas-spec/haskell/timestamp         \
+                      tests/specs/functional/lemmas-spec/java/timestamp            \
+                      tests/specs/functional/merkle-spec/haskell/timestamp         \
+                      tests/specs/functional/storageRoot-spec/haskell/timestamp    \
+                      tests/specs/mcd/functional-spec/haskell/timestamp            \
+                      tests/specs/mcd/functional-spec/java/timestamp               \
+                      tests/specs/mcd/verification/haskell/timestamp               \
+                      tests/specs/mcd/verification/java/timestamp                  \
+                      tests/specs/opcodes/evm-optimizations-spec/haskell/timestamp \
+                      tests/specs/opcodes/verification/java/timestamp
 build-provex: $(provex_definitions)
 
 test-prove: test-prove-benchmarks test-prove-functional test-prove-opcodes test-prove-erc20 test-prove-bihu test-prove-examples test-prove-mcd test-prove-optimizations

--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,6 @@ node_main_filename := $(basename $(notdir $(node_main_file)))
 node_kore          := $(node_dir)/definition.kore
 node_kompiled      := $(node_dir)/build/kevm-vm
 export node_dir
-export node_main_filename
 
 $(KEVM_LIB)/$(node_kore): $(kevm_includes) $(plugin_includes) $(plugin_c_includes) $(libff_out) $(KEVM_BIN)/kevm
 	$(KOMPILE) --backend node                 \

--- a/cmake/node/CMakeLists.txt
+++ b/cmake/node/CMakeLists.txt
@@ -31,7 +31,7 @@ list(APPEND CMAKE_MODULE_PATH "${K_LIB}/cmake/kframework")
 include(LLVMKompilePrelude)
 project (KevmVm CXX)
 
-set(KOMPILED_DIR $ENV{KEVM_LIB_ABS}/$ENV{node_dir}/$ENV{node_main_filename}-kompiled)
+set(KOMPILED_DIR $ENV{KEVM_LIB_ABS}/$ENV{node_dir})
 set(KOMPILE_USE_MAIN "library")
 set(TARGET_NAME "kevm-vm")
 

--- a/kevm
+++ b/kevm
@@ -181,7 +181,7 @@ run_prove() {
         execute kore-prof "${eventlog_name}" ${kore_prof_args} > "${eventlog_name}.json"
     else
         if ${pyk_minimize}; then
-            pyk_args=(${backend_dir}/*-kompiled print /dev/stdin --minimize)
+            pyk_args=(${backend_dir} print /dev/stdin --minimize)
             [[ -z "${pyk_omit_labels}" ]] || pyk_args+=(--omit-labels "${pyk_omit_labels}")
             execute ${kprove} "${proof_args[@]}" "$@" --output json | kpyk "${pyk_args[@]}"
         else
@@ -210,7 +210,7 @@ view_klab() {
 run_interpret() {
     local interpreter kast output output_text output_format exit_status cmdprefix
 
-    interpreter="$backend_dir/driver-kompiled/interpreter"
+    interpreter="$backend_dir/interpreter"
     kast="$(mktemp)"
     output="$(mktemp)"
     output_text="$(mktemp)"
@@ -239,7 +239,7 @@ run_interpret() {
                  ;;
 
         haskell) run_kast kore > "$kast"
-                 execute kore-exec "$backend_dir/driver-kompiled/definition.kore" --pattern "$kast" --module ETHEREUM-SIMULATION --smt none --output "$output" || exit_status="$?"
+                 execute kore-exec "$backend_dir/definition.kore" --pattern "$kast" --module ETHEREUM-SIMULATION --smt none --output "$output" || exit_status="$?"
                  if [[ "$unparse" == 'true' ]] && [[ "$exit_status" != '0' ]]; then
                      cat "$output" | "${KEVM}" kast --backend "$backend" - pretty --input "$output_format" --sort GeneratedTopCell
                  fi
@@ -257,11 +257,11 @@ run_solc() {
     contract_name="$1" ; shift
     json_run_file="${run_file}.json"
 
-    execute python3 -m kevm_pyk solc-to-k "$@" ${backend_dir}/*-kompiled "${run_file}" "${contract_name}"
+    execute python3 -m kevm_pyk ${backend_dir} solc-to-k "$@" "${run_file}" "${contract_name}"
 }
 
 run_gen_spec() {
-    execute python3 -m kevm_pyk gen-spec-modules "$@"
+    execute python3 -m kevm_pyk ${backend_dir} gen-spec-modules "$@"
 }
 
 # Main

--- a/kevm
+++ b/kevm
@@ -53,7 +53,7 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 run_kompile() {
     local kompile_opts openssl_root
 
-    kompile_opts=( "${run_file}" --directory "${backend_dir}" )
+    kompile_opts=( "${run_file}" --output-definition "${backend_dir}" )
     kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
     kompile_opts+=( --hook-namespaces "JSON KRYPTO BLOCKCHAIN"                           )
     kompile_opts+=( --emit-json                                                          )
@@ -111,7 +111,7 @@ run_krun() {
             parser='cat'
             ;;
     esac
-    execute krun --directory "$backend_dir"           \
+    execute krun --definition "$backend_dir"          \
          -cSCHEDULE="$cschedule" -pSCHEDULE="$parser" \
          -cMODE="$cmode"         -pMODE="$parser"     \
          -cCHAINID="$cchainid"   -pCHAINID="$parser"  \
@@ -124,9 +124,9 @@ run_kast() {
     output_mode="${1:-kore}" ; shift
 
     case "$run_file-$output_mode" in
-        *.json-kast) execute kast-json.py "$run_file" "$cSCHEDULE_kast" "$cMODE_kast" "$cCHAINID_kast"          ;;
-        *.json-kore) execute kore-json.py "$run_file" "$cSCHEDULE_kore" "$cMODE_kore" "$cCHAINID_kore"          ;;
-        *)           check_k_install ; kast --directory "$backend_dir" "$run_file" --output "$output_mode" "$@" ;;
+        *.json-kast) execute kast-json.py "$run_file" "$cSCHEDULE_kast" "$cMODE_kast" "$cCHAINID_kast"           ;;
+        *.json-kore) execute kore-json.py "$run_file" "$cSCHEDULE_kore" "$cMODE_kore" "$cCHAINID_kore"           ;;
+        *)           check_k_install ; kast --definition "$backend_dir" "$run_file" --output "$output_mode" "$@" ;;
     esac
 }
 
@@ -140,7 +140,7 @@ run_prove() {
     eventlog_name="${run_file}.eventlog"
 
     kprove=kprove
-    proof_args=(--directory "${backend_dir}" "${run_file}")
+    proof_args=(--definition "${backend_dir}" "${run_file}")
     proof_args+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
 
     ! ${provex} || kprove=kprovex
@@ -373,7 +373,7 @@ while [[ $# -gt 0 ]]; do
         --kore-prof-args)      kore_prof_args="$2"             ; shift 2 ;;
         --bug-report)          bug_report=true                 ; shift   ;;
         --backend)             backend="$2"                    ; shift 2 ;;
-        --directory)           backend_dir="$2"                ; shift 2 ;;
+        --definition)          backend_dir="$2"                ; shift 2 ;;
         --concrete-rules-file) concrete_rules_file="$2"        ; shift 2 ;;
         --no-provex)           provex=false                    ; shift   ;;
         --verif-module)        verif_module="$2"               ; shift 2 ;;

--- a/kevm
+++ b/kevm
@@ -257,11 +257,11 @@ run_solc() {
     contract_name="$1" ; shift
     json_run_file="${run_file}.json"
 
-    execute python3 -m kevm_pyk ${backend_dir} solc-to-k "$@" "${run_file}" "${contract_name}"
+    execute python3 -m kevm_pyk solc-to-k ${backend_dir} "$@" "${run_file}" "${contract_name}"
 }
 
 run_gen_spec() {
-    execute python3 -m kevm_pyk ${backend_dir} gen-spec-modules "$@"
+    execute python3 -m kevm_pyk gen-spec-modules ${backend_dir} "$@"
 }
 
 # Main

--- a/kevm
+++ b/kevm
@@ -261,7 +261,7 @@ run_solc() {
 }
 
 run_gen_spec() {
-    execute python3 -m kevm_pyk gen-spec-modules "${backend_dir}" "${run_file}" "$@"
+    execute python3 -m kevm_pyk gen-spec-modules "${backend_dir}" "$@"
 }
 
 # Main
@@ -279,8 +279,8 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                ${KEVM} search       [--backend (java|haskell)]                [--profile|--debug]             <pgm>  <pattern> <K arg>*
                ${KEVM} kompile      [--backend (java|llvm|haskell)]           [--profile|--debug]             <main> <K arg>*
                ${KEVM} klab-view                                              [--profile|--debug]             <spec>
-               ${KEVM} solc-to-k                                              [--profile|--debug]             <sol> <sol contract> <solc arg>*
-               ${KEVM} gen-spec                                               [--profile|--debug]
+               ${KEVM} solc-to-k                                              [--profile|--debug]             <sol-file> <contract-name> <solc-arg>*
+               ${KEVM} gen-spec                                               [--profile|--debug]             <module-name>
 
                ${KEVM} [help|--help|version|--version]
 

--- a/kevm
+++ b/kevm
@@ -257,11 +257,11 @@ run_solc() {
     contract_name="$1" ; shift
     json_run_file="${run_file}.json"
 
-    execute python3 -m kevm_pyk solc-to-k ${backend_dir} "$@" "${run_file}" "${contract_name}"
+    execute python3 -m kevm_pyk solc-to-k "${backend_dir}" "${run_file}" "${contract_name}" "$@"
 }
 
 run_gen_spec() {
-    execute python3 -m kevm_pyk gen-spec-modules ${backend_dir} "$@"
+    execute python3 -m kevm_pyk gen-spec-modules "${backend_dir}" "${run_file}" "$@"
 }
 
 # Main
@@ -280,7 +280,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                ${KEVM} kompile      [--backend (java|llvm|haskell)]           [--profile|--debug]             <main> <K arg>*
                ${KEVM} klab-view                                              [--profile|--debug]             <spec>
                ${KEVM} solc-to-k                                              [--profile|--debug]             <sol> <sol contract> <solc arg>*
-               ${KEVM} gen-spec                                               [--profile|--debug]             <kompiled-dir>
+               ${KEVM} gen-spec                                               [--profile|--debug]
 
                ${KEVM} [help|--help|version|--version]
 

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -41,13 +41,13 @@ def create_argument_parser():
     solc_subparser.add_argument('contract_file', type=file_path, help='Path to contract file.')
 
     solc_to_k_subparser = command_parser.add_parser('solc-to-k', help='Output helper K definition for given JSON output from solc compiler.')
-    solc_to_k_subparser.add_argument('definition-dir', type=dir_path, help='Path to definition to use.')
+    solc_to_k_subparser.add_argument('definition_dir', type=dir_path, help='Path to definition to use.')
     solc_to_k_subparser.add_argument('contract_file', type=file_path, help='Path to contract file.')
     solc_to_k_subparser.add_argument('contract_name', type=str, help='Name of contract to generate K helpers for.')
     solc_to_k_subparser.add_argument('--no-storage-slots', dest='generate_storage', default=True, action='store_false', help='Do not generate productions and rules for accessing storage slots')
 
     gen_spec_modules_subparser = command_parser.add_parser('gen-spec-modules', help='Output helper K definition for given JSON output from solc compiler.')
-    gen_spec_modules_subparser.add_argument('definition-dir', type=dir_path, help='Path to definition to use.')
+    gen_spec_modules_subparser.add_argument('definition_dir', type=dir_path, help='Path to definition to use.')
     gen_spec_modules_subparser.add_argument('spec_module_name', type=str, help='Name of module containing all the generated specs.')
 
     return parser

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -18,7 +18,7 @@ def main():
 
     elif args.command == 'solc-to-k':
         res = solc_to_k(
-            kompiled_directory=args.kompiled_directory,
+            definition_dir=args.definition_dir,
             contract_file=args.contract_file,
             contract_name=args.contract_name,
             generate_storage=args.generate_storage,
@@ -26,7 +26,7 @@ def main():
         print(res)
 
     elif args.command == 'gen-spec-modules':
-        res = gen_spec_modules(args.kompiled_directory, args.spec_module_name)
+        res = gen_spec_modules(args.definition_dir, args.spec_module_name)
         print(res)
 
     else:
@@ -41,13 +41,13 @@ def create_argument_parser():
     solc_subparser.add_argument('contract_file', type=file_path, help='Path to contract file.')
 
     solc_to_k_subparser = command_parser.add_parser('solc-to-k', help='Output helper K definition for given JSON output from solc compiler.')
-    solc_to_k_subparser.add_argument('kompiled_directory', type=dir_path, help='Path to *-kompiled directory to use.')
+    solc_to_k_subparser.add_argument('definition-dir', type=dir_path, help='Path to definition to use.')
     solc_to_k_subparser.add_argument('contract_file', type=file_path, help='Path to contract file.')
     solc_to_k_subparser.add_argument('contract_name', type=str, help='Name of contract to generate K helpers for.')
     solc_to_k_subparser.add_argument('--no-storage-slots', dest='generate_storage', default=True, action='store_false', help='Do not generate productions and rules for accessing storage slots')
 
     gen_spec_modules_subparser = command_parser.add_parser('gen-spec-modules', help='Output helper K definition for given JSON output from solc compiler.')
-    gen_spec_modules_subparser.add_argument('kompiled_directory', type=dir_path, help='Path to kompiled JSON definition to generate specs for.')
+    gen_spec_modules_subparser.add_argument('definition-dir', type=dir_path, help='Path to definition to use.')
     gen_spec_modules_subparser.add_argument('spec_module_name', type=str, help='Name of module containing all the generated specs.')
 
     return parser

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -79,8 +79,8 @@ def gen_claims_for_contract(kevm: KPrint, contract_name: str) -> List[KClaim]:
     return [claim]
 
 
-def gen_spec_modules(kompiled_directory: Path, spec_module_name: str) -> str:
-    kevm = KPrint(str(kompiled_directory))
+def gen_spec_modules(definition_dir: Path, spec_module_name: str) -> str:
+    kevm = KPrint(str(definition_dir))
     kevm.symbolTable = kevmSymbolTable(kevm.symbolTable)
     production_labels = [prod.klabel for module in kevm.definition for prod in module.productions if prod.klabel is not None]
     contract_names = [prod_label[9:] for prod_label in production_labels if prod_label.startswith('contract_')]
@@ -90,8 +90,8 @@ def gen_spec_modules(kompiled_directory: Path, spec_module_name: str) -> str:
     return kevm.prettyPrint(spec_defn)
 
 
-def solc_to_k(kompiled_directory: Path, contract_file: Path, contract_name: str, generate_storage: bool):
-    kevm = KPrint(str(kompiled_directory))
+def solc_to_k(definition_dir: Path, contract_file: Path, contract_name: str, generate_storage: bool):
+    kevm = KPrint(str(definition_dir))
     kevm.symbolTable = kevmSymbolTable(kevm.symbolTable)
 
     solc_json = solc_compile(contract_file)

--- a/optimizer/optimize.sh
+++ b/optimizer/optimize.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 export PATH=$(pwd)/.build/usr/bin:$PATH
 export PYTHONPATH=$(pwd)/.build/usr/lib/kevm/kframework/lib/kframework
 
-kevm_json_defn=$(pwd)/.build/usr/lib/kevm/haskell/driver-kompiled/compiled.json
+kevm_json_defn=$(pwd)/.build/usr/lib/kevm/haskell/compiled.json
 
 notif() { echo "$@" >&2 ; }
 

--- a/package/test-package.sh
+++ b/package/test-package.sh
@@ -24,19 +24,19 @@ rm -rf tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.llv
 
 kevm solc-to-k tests/specs/examples/ERC20.sol ERC20 > tests/specs/examples/erc20-bin-runtime.k
 kevm kompile --backend haskell tests/specs/examples/erc20-spec.md \
-    --directory tests/specs/examples/erc20-spec/haskell           \
+    --definition tests/specs/examples/erc20-spec/haskell          \
     --main-module VERIFICATION                                    \
     --syntax-module VERIFICATION                                  \
     --concrete-rules-file tests/specs/examples/concrete-rules.txt \
     --verbose
 kevm prove tests/specs/examples/erc20-spec.md --backend haskell --format-failures  \
-    --directory tests/specs/examples/erc20-spec/haskell
+    --definition tests/specs/examples/erc20-spec/haskell
 
 kevm kompile --backend java tests/specs/erc20/verification.k   \
-    --directory tests/specs/erc20/verification/java            \
+    --definition tests/specs/erc20/verification/java           \
     --main-module VERIFICATION                                 \
     --syntax-module VERIFICATION                               \
     --concrete-rules-file tests/specs/erc20/concrete-rules.txt \
     --debug
 kevm prove tests/specs/erc20/ds/transfer-failure-1-a-spec.k --backend java --format-failures --debugger \
-    --directory tests/specs/erc20/verification/java
+    --definition tests/specs/erc20/verification/java


### PR DESCRIPTION
~Blocked on: https://github.com/runtimeverification/evm-semantics/pull/1240~

Fortunately KEVM was already using a unique wrapper directory for every definition it `kompile`d anyway, so this only needs us to remove references to teh `*-kompiled` directories (instead preferring the unique wrapper directory for every definition), and to switch to using the `--definition` flag everywhere.