### PR TITLE
flipper-bids-pass-rough-spec.k passing

### DIFF
--- a/tests/specs/mcd/flipper-bids-pass-rough-spec.k
+++ b/tests/specs/mcd/flipper-bids-pass-rough-spec.k
@@ -116,7 +116,7 @@ module FLIPPER-BIDS-PASS-ROUGH-SPEC
 
        andBool #lookup(ACCT_ID_STORAGE, #Flipper.bids[ABI_n].bid) ==Int Bid
        andBool #lookup(ACCT_ID_STORAGE, #Flipper.bids[ABI_n].lot) ==Int Lot
-       andBool #lookup(ACCT_ID_STORAGE, #Flipper.bids[ABI_n].guy_tic_end) ==Int #WordPackAddrUInt48UInt48(Guy, Tic, End)
+       andBool #WordPackAddrUInt48UInt48Prop(#lookup(ACCT_ID_STORAGE, #Flipper.bids[ABI_n].guy_tic_end), Guy, Tic, End)
        andBool #lookup(ACCT_ID_STORAGE, #Flipper.bids[ABI_n].usr) ==Int Usr
        andBool #lookup(ACCT_ID_STORAGE, #Flipper.bids[ABI_n].gal) ==Int Gal
        andBool #lookup(ACCT_ID_STORAGE, #Flipper.bids[ABI_n].tab) ==Int Tab

--- a/tests/specs/mcd/word-pack.k
+++ b/tests/specs/mcd/word-pack.k
@@ -53,6 +53,15 @@ module WORD-PACK-HASKELL [kore]
     andBool #rangeUInt(256, ADDR_UINT48_UINT48)
       [simplification]
 
+
+    rule     #WordPackAddrUInt48UInt48Prop(ADDR_UINT48_UINT48, ADDR, UINT48_1, UINT48_2)
+          => true
+     ensures ADDR     ==Int maxUInt160 &Int  ADDR_UINT48_UINT48
+     andBool UINT48_1 ==Int maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow160)
+     andBool UINT48_2 ==Int maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow208)
+     andBool #rangeUInt(256, ADDR_UINT48_UINT48)
+       [simplification]
+
     rule    UINT48_UINT48 ==Int #WordPackUInt48UInt48(UINT48_1, UINT48_2)
          => UINT48_1 ==Int maxUInt48 &Int  UINT48_UINT48
     andBool UINT48_2 ==Int maxUInt48 &Int (UINT48_UINT48 /Int pow48)
@@ -78,6 +87,9 @@ module WORD-PACK-COMMON
     syntax Int ::= #WordPackUInt48UInt48     (       Int , Int ) [function, no-evaluators, smtlib(WordPackUInt48UInt48)]
                  | #WordPackAddrUInt48UInt48 ( Int , Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt48UInt48)]
                  | #WordPackAddrUInt8        (       Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt8)]
+
+    syntax Bool ::= #WordPackAddrUInt48UInt48Prop ( Int , Int , Int, Int ) [function, smtlib(WordPackAddrUInt48UInt48Bool)]
+
  // -----------------------------------------------------------------------------------------------------------------
     // rule #WordPackUInt48UInt48     (            UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow48 +Int UINT48_1                        requires #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
     // rule #WordPackAddrUInt48UInt48 (     ADDR , UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow208 +Int UINT48_1 *Int pow160 +Int ADDR requires #rangeAddress(ADDR) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)


### PR DESCRIPTION
Due to https://github.com/runtimeverification/haskell-backend/issues/3060, the definition and simplification rule for `#WordPackAddrUInt48UInt48` was tweaked slightly to allow the proof in `flipper-bids-pass-rough-spec.k` to pass.