### PR TITLE
Drop kprovex

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         }
       }
       stages {
-        stage('Build') { steps { sh 'make build build-provex RELEASE=true -j6' } }
+        stage('Build') { steps { sh 'make build build-prove RELEASE=true -j6' } }
         stage('Test') {
           failFast true
           options { timeout(time: 200, unit: 'MINUTES') }

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ export PLUGIN_SUBMODULE
 
 .PHONY: all clean distclean                                                                                                      \
         deps k-deps plugin-deps libsecp256k1 libff protobuf                                                                      \
-        build build-haskell build-llvm build-prove build-node build-kevm                                                        \
+        build build-haskell build-llvm build-prove build-node build-kevm                                                         \
         test test-all test-conformance test-rest-conformance test-all-conformance test-slow-conformance test-failing-conformance \
         test-vm test-rest-vm test-all-vm test-bchain test-rest-bchain test-all-bchain test-node                                  \
         test-prove test-failing-prove                                                                                            \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ export PLUGIN_SUBMODULE
 
 .PHONY: all clean distclean                                                                                                      \
         deps k-deps plugin-deps libsecp256k1 libff protobuf                                                                      \
-        build build-haskell build-llvm build-provex build-node build-kevm                                                        \
+        build build-haskell build-llvm build-prove build-node build-kevm                                                        \
         test test-all test-conformance test-rest-conformance test-all-conformance test-slow-conformance test-failing-conformance \
         test-vm test-rest-vm test-all-vm test-bchain test-rest-bchain test-all-bchain test-node                                  \
         test-prove test-failing-prove                                                                                            \
@@ -423,11 +423,6 @@ tests/%.parse: tests/%
 	$(CHECK) $@-out $@-expected
 	$(KEEP_OUTPUTS) || rm -rf $@-out
 
-tests/%.prove-legacy: tests/%
-	$(KEVM) prove $< --verif-module $(KPROVE_MODULE) $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) \
-	    --no-provex --format-failures $(KPROVE_OPTS) --concrete-rules-file $(dir $@)concrete-rules.txt
-
-
 # solc-to-k
 # ---------
 
@@ -526,38 +521,38 @@ prove_examples_tests     := $(filter-out $(prove_skip_tests), $(wildcard $(prove
 prove_mcd_tests          := $(filter-out $(prove_skip_tests), $(wildcard $(prove_specs_dir)/mcd/*-spec.k))
 prove_optimization_tests := $(filter-out $(prove_skip_tests), tests/specs/opcodes/evm-optimizations-spec.md)
 
-## best-effort list of provex kompiled definitions to produce ahead of time
-provex_definitions :=                                                              \
-                      tests/specs/benchmarks/functional-spec/haskell/timestamp     \
-                      tests/specs/benchmarks/functional-spec/java/timestamp        \
-                      tests/specs/benchmarks/verification/haskell/timestamp        \
-                      tests/specs/benchmarks/verification/java/timestamp           \
-                      tests/specs/bihu/functional-spec/haskell/timestamp           \
-                      tests/specs/bihu/functional-spec/java/timestamp              \
-                      tests/specs/bihu/verification/haskell/timestamp              \
-                      tests/specs/bihu/verification/java/timestamp                 \
-                      tests/specs/erc20/verification/haskell/timestamp             \
-                      tests/specs/erc20/verification/java/timestamp                \
-                      tests/specs/examples/erc20-spec/haskell/timestamp            \
-                      tests/specs/examples/erc721-spec/haskell/timestamp           \
-                      tests/specs/examples/solidity-code-spec/haskell/timestamp    \
-                      tests/specs/examples/solidity-code-spec/java/timestamp       \
-                      tests/specs/examples/sum-to-n-spec/haskell/timestamp         \
-                      tests/specs/examples/sum-to-n-spec/java/timestamp            \
-                      tests/specs/functional/infinite-gas-spec/haskell/timestamp   \
-                      tests/specs/functional/lemmas-no-smt-spec/haskell/timestamp  \
-                      tests/specs/functional/lemmas-no-smt-spec/java/timestamp     \
-                      tests/specs/functional/lemmas-spec/haskell/timestamp         \
-                      tests/specs/functional/lemmas-spec/java/timestamp            \
-                      tests/specs/functional/merkle-spec/haskell/timestamp         \
-                      tests/specs/functional/storageRoot-spec/haskell/timestamp    \
-                      tests/specs/mcd/functional-spec/haskell/timestamp            \
-                      tests/specs/mcd/functional-spec/java/timestamp               \
-                      tests/specs/mcd/verification/haskell/timestamp               \
-                      tests/specs/mcd/verification/java/timestamp                  \
-                      tests/specs/opcodes/evm-optimizations-spec/haskell/timestamp \
-                      tests/specs/opcodes/verification/java/timestamp
-build-provex: $(provex_definitions)
+## best-effort list of prove kompiled definitions to produce ahead of time
+prove_definitions :=                                                              \
+                     tests/specs/benchmarks/functional-spec/haskell/timestamp     \
+                     tests/specs/benchmarks/functional-spec/java/timestamp        \
+                     tests/specs/benchmarks/verification/haskell/timestamp        \
+                     tests/specs/benchmarks/verification/java/timestamp           \
+                     tests/specs/bihu/functional-spec/haskell/timestamp           \
+                     tests/specs/bihu/functional-spec/java/timestamp              \
+                     tests/specs/bihu/verification/haskell/timestamp              \
+                     tests/specs/bihu/verification/java/timestamp                 \
+                     tests/specs/erc20/verification/haskell/timestamp             \
+                     tests/specs/erc20/verification/java/timestamp                \
+                     tests/specs/examples/erc20-spec/haskell/timestamp            \
+                     tests/specs/examples/erc721-spec/haskell/timestamp           \
+                     tests/specs/examples/solidity-code-spec/haskell/timestamp    \
+                     tests/specs/examples/solidity-code-spec/java/timestamp       \
+                     tests/specs/examples/sum-to-n-spec/haskell/timestamp         \
+                     tests/specs/examples/sum-to-n-spec/java/timestamp            \
+                     tests/specs/functional/infinite-gas-spec/haskell/timestamp   \
+                     tests/specs/functional/lemmas-no-smt-spec/haskell/timestamp  \
+                     tests/specs/functional/lemmas-no-smt-spec/java/timestamp     \
+                     tests/specs/functional/lemmas-spec/haskell/timestamp         \
+                     tests/specs/functional/lemmas-spec/java/timestamp            \
+                     tests/specs/functional/merkle-spec/haskell/timestamp         \
+                     tests/specs/functional/storageRoot-spec/haskell/timestamp    \
+                     tests/specs/mcd/functional-spec/haskell/timestamp            \
+                     tests/specs/mcd/functional-spec/java/timestamp               \
+                     tests/specs/mcd/verification/haskell/timestamp               \
+                     tests/specs/mcd/verification/java/timestamp                  \
+                     tests/specs/opcodes/evm-optimizations-spec/haskell/timestamp \
+                     tests/specs/opcodes/verification/java/timestamp
+build-prove: $(prove_definitions)
 
 test-prove: test-prove-benchmarks test-prove-functional test-prove-opcodes test-prove-erc20 test-prove-bihu test-prove-examples test-prove-mcd test-prove-optimizations
 test-prove-benchmarks:    $(prove_benchmarks_tests:=.prove)

--- a/kevm
+++ b/kevm
@@ -139,12 +139,8 @@ run_prove() {
     bug_report_name="kevm-bug-$(basename "${run_file%-spec.k}")"
     eventlog_name="${run_file}.eventlog"
 
-    kprove=kprove
     proof_args=(--definition "${backend_dir}" "${run_file}")
     proof_args+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
-
-    ! ${provex} || kprove=kprovex
-      ${provex} || proof_args+=(--def-module "$verif_module")
 
     ! ${debug}                        || proof_args+=(--debug)
     [[ ! -f ${concrete_rules_file} ]] || proof_args+=(--concrete-rules "$(cat ${concrete_rules_file} | tr '\n' ',')")
@@ -183,9 +179,9 @@ run_prove() {
         if ${pyk_minimize}; then
             pyk_args=(${backend_dir} print /dev/stdin --minimize)
             [[ -z "${pyk_omit_labels}" ]] || pyk_args+=(--omit-labels "${pyk_omit_labels}")
-            execute ${kprove} "${proof_args[@]}" "$@" --output json | kpyk "${pyk_args[@]}"
+            execute kprove "${proof_args[@]}" "$@" --output json | kpyk "${pyk_args[@]}"
         else
-            execute ${kprove} "${proof_args[@]}" "$@"
+            execute kprove "${proof_args[@]}" "$@"
         fi
     fi
 }
@@ -308,7 +304,6 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                                       [--profile-haskell]
                                       [--profile-timeout <duration>]
                                       [--kore-prof-args \"<kore-prof arg>*\"]
-                                      [--no-provex]
                                       [--verif-module <verification_module>]
                                       [--pyk-minimize]
                                       [--pyk-omit-labels <comma_separated_labels>]
@@ -349,7 +344,6 @@ mode=NORMAL
 schedule=LONDON
 chainid=1
 concrete_rules_file=
-provex=true
 verif_module=VERIFICATION
 pyk_minimize=false
 pyk_omit_labels=
@@ -375,7 +369,6 @@ while [[ $# -gt 0 ]]; do
         --backend)             backend="$2"                    ; shift 2 ;;
         --definition)          backend_dir="$2"                ; shift 2 ;;
         --concrete-rules-file) concrete_rules_file="$2"        ; shift 2 ;;
-        --no-provex)           provex=false                    ; shift   ;;
         --verif-module)        verif_module="$2"               ; shift 2 ;;
         --pyk-minimize)        pyk_minimize=true               ; shift   ;;
         --pyk-omit-labels)     pyk_omit_labels="$2"            ; shift 2 ;;

--- a/tests/failing-symbolic.java
+++ b/tests/failing-symbolic.java
@@ -1,4 +1,5 @@
 tests/specs/examples/erc20-spec.md
+tests/specs/examples/erc721-spec.md
 tests/specs/functional/infinite-gas-spec.k
 tests/specs/functional/merkle-spec.k
 tests/specs/functional/storageRoot-spec.k

--- a/tests/slow.haskell
+++ b/tests/slow.haskell
@@ -353,7 +353,6 @@ tests/specs/erc20/ds/transfer-success-2-spec.k
 tests/specs/erc20/hkg/transferFrom-failure-1-spec.k
 tests/specs/erc20/hkg/transferFrom-success-1-spec.k
 tests/specs/examples/erc20-spec.md
-tests/specs/examples/erc721-spec.md
 tests/specs/mcd/dstoken-approve-fail-rough-spec.k
 tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
 tests/specs/mcd/vat-flux-diff-pass-rough-spec.k


### PR DESCRIPTION
This PR:

- Removes references to the old `kprovex`.
- Switches `erc721` spec to be proven with Haskell backend, not Java backend, because now Java backend is consistently failing on that proof on CI.