### PR TITLE
Add pyk runner for prover and kompile, rule profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /pkg
 /src
 /tests/**/*.debug-log
+/tests/**/*.rule-profile
 /tests/gen-spec/*.out
 /tests/gen-spec/*.sol
 /tests/specs/**/*-bin-runtime.k

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /package/src
 /pkg
 /src
+/tests/**/*.debuglog
 /tests/gen-spec/*.out
 /tests/gen-spec/*.sol
 /tests/specs/**/*-bin-runtime.k

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 /package/src
 /pkg
 /src
-/tests/**/*.debuglog
+/tests/**/*.debug-log
 /tests/gen-spec/*.out
 /tests/gen-spec/*.sol
 /tests/specs/**/*-bin-runtime.k

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,9 @@ pipeline {
       }
       stages {
         // Must come before build/prove for proper testing
-        stage('Build Pyk') { steps { sh 'make test-kevm-pyk -j3'                  } }
-        stage('Build')     { steps { sh 'make build build-prove RELEASE=true -j6' } }
+        stage('Setup Pyk') { steps { sh 'make kevm-pyk-venv'                      } }
+        stage('Build Pyk') { steps { sh 'make test-kevm-pyk -j2'                  } }
+        stage('Build')     { steps { sh 'make build build-prove RELEASE=true -j2' } }
         stage('Test') {
           failFast true
           options { timeout(time: 200, unit: 'MINUTES') }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,9 @@ pipeline {
         }
       }
       stages {
-        stage('Build') { steps { sh 'make build build-prove RELEASE=true -j6' } }
+        // Must come before build/prove for proper testing
+        stage('Build Pyk') { steps { sh 'make test-kevm-pyk -j3'                  } }
+        stage('Build')     { steps { sh 'make build build-prove RELEASE=true -j6' } }
         stage('Test') {
           failFast true
           options { timeout(time: 200, unit: 'MINUTES') }
@@ -35,12 +37,11 @@ pipeline {
         stage('Test Interactive') {
           options { timeout(time: 35, unit: 'MINUTES') }
           parallel {
-            stage('LLVM krun')      { steps { sh 'make test-interactive-run TEST_CONCRETE_BACKEND=llvm' } }
-            stage('LLVM Kast')      { steps { sh 'make test-parse TEST_CONCRETE_BACKEND=llvm'           } }
-            stage('Failing tests')  { steps { sh 'make test-failure TEST_CONCRETE_BACKEND=llvm'         } }
-            stage('KEVM VM')        { steps { sh 'make test-node'                                       } }
-            stage('KEVM pyk')       { steps { sh 'make test-kevm-pyk'                                   } }
-            stage('KEVM help')      { steps { sh './kevm help'                                          } }
+            stage('LLVM krun')     { steps { sh 'make test-interactive-run TEST_CONCRETE_BACKEND=llvm' } }
+            stage('LLVM Kast')     { steps { sh 'make test-parse TEST_CONCRETE_BACKEND=llvm'           } }
+            stage('Failing tests') { steps { sh 'make test-failure TEST_CONCRETE_BACKEND=llvm'         } }
+            stage('KEVM VM')       { steps { sh 'make test-node'                                       } }
+            stage('KEVM help')     { steps { sh './kevm help'                                          } }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,9 +23,9 @@ pipeline {
       }
       stages {
         // Must come before build/prove for proper testing
-        stage('Setup Pyk') { steps { sh 'make kevm-pyk-venv'                      } }
-        stage('Build Pyk') { steps { sh 'make test-kevm-pyk -j2'                  } }
-        stage('Build')     { steps { sh 'make build build-prove RELEASE=true -j2' } }
+        stage('Setup Pyk')          { steps { sh 'make kevm-pyk-venv'                      } }
+        stage('Build and Test Pyk') { steps { sh 'make test-kevm-pyk -j2'                  } }
+        stage('Build')              { steps { sh 'make build build-prove RELEASE=true -j2' } }
         stage('Test') {
           failFast true
           options { timeout(time: 200, unit: 'MINUTES') }

--- a/Makefile
+++ b/Makefile
@@ -599,7 +599,7 @@ test-kevm-pyk: KPROVE_OPTS  += --pyk --verbose
 test-kevm-pyk: KOMPILE_OPTS += --pyk --verbose
 test-kevm-pyk: KEVM = . ./kevm_pyk/venv-prod/bin/activate && kevm
 test-kevm-pyk: KOMPILE = . ./kevm_pyk/venv-prod/bin/activate && kevm kompile
-test-kevm-pyk: $(kevm_pyk_tests)
+test-kevm-pyk: $(kevm_pyk_tests) kevm-pyk-venv
 	wc -l tests/specs/bihu/functional-spec.rule-profile
 
 # Interactive Tests

--- a/Makefile
+++ b/Makefile
@@ -592,8 +592,10 @@ test-failure: $(failure_tests:=.run-expected)
 kevm_pyk_tests := tests/specs/examples/empty-bin-runtime.k \
                   tests/specs/examples/erc20-bin-runtime.k \
                   tests/specs/examples/erc721-bin-runtime.k \
-                  tests/gen-spec/mcd-spec.k.check
+                  tests/gen-spec/mcd-spec.k.check           \
+                  tests/specs/bihu/functional-spec.k.prove
 
+test-kevm-pyk: KPROVE_OPTS += --pyk-prove
 test-kevm-pyk: $(kevm_pyk_tests)
 
 # Interactive Tests

--- a/Makefile
+++ b/Makefile
@@ -599,7 +599,7 @@ test-kevm-pyk: KPROVE_OPTS  += --pyk --verbose
 test-kevm-pyk: KOMPILE_OPTS += --pyk --verbose
 test-kevm-pyk: KEVM = . ./kevm_pyk/venv-prod/bin/activate && kevm
 test-kevm-pyk: KOMPILE = . ./kevm_pyk/venv-prod/bin/activate && kevm kompile
-test-kevm-pyk: $(kevm_pyk_tests) kevm-pyk-venv
+test-kevm-pyk: $(kevm_pyk_tests)
 	wc -l tests/specs/bihu/functional-spec.rule-profile
 
 # Interactive Tests

--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ tests/gen-spec/kompiled/timestamp: tests/gen-spec/verification.k
 
 .SECONDEXPANSION:
 tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/timestamp
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $(KPROVE_OPTS) \
+	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $(KPROVE_OPTS) \
 	    --definition tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
 tests/specs/%/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
@@ -596,6 +596,7 @@ kevm_pyk_tests := tests/specs/examples/empty-bin-runtime.k \
                   tests/specs/bihu/functional-spec.k.prove
 
 test-kevm-pyk: KPROVE_OPTS += --pyk-prove
+test-kevm-pyk: KEVM = . ./kevm_pyk/venv-prod/bin/activate && kevm
 test-kevm-pyk: $(kevm_pyk_tests)
 
 # Interactive Tests

--- a/Makefile
+++ b/Makefile
@@ -600,6 +600,7 @@ test-kevm-pyk: KOMPILE_OPTS += --pyk --verbose
 test-kevm-pyk: KEVM = . ./kevm_pyk/venv-prod/bin/activate && kevm
 test-kevm-pyk: KOMPILE = . ./kevm_pyk/venv-prod/bin/activate && kevm kompile
 test-kevm-pyk: $(kevm_pyk_tests)
+	wc -l tests/specs/bihu/functional-spec.rule-profile
 
 # Interactive Tests
 

--- a/Makefile
+++ b/Makefile
@@ -450,7 +450,7 @@ tests/gen-spec/kompiled/timestamp: tests/gen-spec/verification.k
 
 .SECONDEXPANSION:
 tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/timestamp
-	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS) \
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $(KPROVE_OPTS) \
 	    --definition tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
 tests/specs/%/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm

--- a/Makefile
+++ b/Makefile
@@ -595,8 +595,10 @@ kevm_pyk_tests := tests/specs/examples/empty-bin-runtime.k \
                   tests/gen-spec/mcd-spec.k.check           \
                   tests/specs/bihu/functional-spec.k.prove
 
-test-kevm-pyk: KPROVE_OPTS += --pyk-prove
+test-kevm-pyk: KPROVE_OPTS  += --pyk
+test-kevm-pyk: KOMPILE_OPTS += --pyk
 test-kevm-pyk: KEVM = . ./kevm_pyk/venv-prod/bin/activate && kevm
+test-kevm-pyk: KOMPILE = . ./kevm_pyk/venv-prod/bin/activate && kevm kompile
 test-kevm-pyk: $(kevm_pyk_tests)
 
 # Interactive Tests

--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ tests/gen-spec/mcd-spec.k.check: tests/gen-spec/kompiled/timestamp kevm-pyk-venv
 	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) gen-spec MCD-SPEC --definition tests/gen-spec/kompiled > $@.out
 	$(CHECK) $@.out $@.expected
 
-tests/gen-spec/kompiled/timestamp: tests/gen-spec/verification.k
+tests/gen-spec/kompiled/timestamp: tests/gen-spec/verification.k $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
 	$(KOMPILE) --backend haskell --definition tests/gen-spec/kompiled $< --main-module MCD-VERIFICATION
 
 
@@ -589,14 +589,14 @@ test-failure: $(failure_tests:=.run-expected)
 
 # kevm_pyk Tests
 
-kevm_pyk_tests := tests/specs/examples/empty-bin-runtime.k \
-                  tests/specs/examples/erc20-bin-runtime.k \
+kevm_pyk_tests := tests/specs/examples/empty-bin-runtime.k  \
+                  tests/specs/examples/erc20-bin-runtime.k  \
                   tests/specs/examples/erc721-bin-runtime.k \
                   tests/gen-spec/mcd-spec.k.check           \
                   tests/specs/bihu/functional-spec.k.prove
 
-test-kevm-pyk: KPROVE_OPTS  += --pyk
-test-kevm-pyk: KOMPILE_OPTS += --pyk
+test-kevm-pyk: KPROVE_OPTS  += --pyk --verbose
+test-kevm-pyk: KOMPILE_OPTS += --pyk --verbose
 test-kevm-pyk: KEVM = . ./kevm_pyk/venv-prod/bin/activate && kevm
 test-kevm-pyk: KOMPILE = . ./kevm_pyk/venv-prod/bin/activate && kevm kompile
 test-kevm-pyk: $(kevm_pyk_tests)

--- a/kevm
+++ b/kevm
@@ -49,6 +49,7 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 # -------
 
 run_kevm_pyk() {
+    local pyk_args
     pyk_args=(--definition "${backend_dir}")
     pyk_args+=(-I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework")
     ! ${debug} || pyk_args+=(--debug)
@@ -139,7 +140,7 @@ run_kast() {
 
 run_prove() {
     local def_module run_dir proof_args bug_report_name \
-          eventlog_name kprove omit_cells omit_labels klab_log pyk_args
+          eventlog_name kprove omit_cells omit_labels klab_log
 
     check_k_install
 
@@ -147,7 +148,7 @@ run_prove() {
     eventlog_name="${run_file}.eventlog"
 
     proof_args=("${run_file}")
-    if ! ${pyk_prove}; then
+    if ! ${pyk}; then
         proof_args+=(--definition "${backend_dir}")
         proof_args+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
         ! ${debug} || proof_args+=(--debug)
@@ -187,7 +188,7 @@ run_prove() {
         timeout -s INT "${profile_timeout}" ${kprove} "${proof_args[@]}" "$@" || true
         execute kore-prof "${eventlog_name}" ${kore_prof_args} > "${eventlog_name}.json"
     else
-        if ${pyk_prove}; then
+        if ${pyk}; then
             run_kevm_pyk prove "${proof_args[@]}" "$@"
         else
             execute kprove "${proof_args[@]}" "$@"
@@ -352,7 +353,7 @@ schedule=LONDON
 chainid=1
 concrete_rules_file=
 verif_module=VERIFICATION
-pyk_prove=false
+pyk=false
 max_counterexamples=
 branching_allowed=
 haskell_backend_command=(kore-exec)
@@ -376,7 +377,7 @@ while [[ $# -gt 0 ]]; do
         --definition)          backend_dir="$2"                ; shift 2 ;;
         --concrete-rules-file) concrete_rules_file="$2"        ; shift 2 ;;
         --verif-module)        verif_module="$2"               ; shift 2 ;;
-        --pyk-prove)           pyk_prove=true                  ; shift   ;;
+        --pyk)                 pyk=true                        ; shift   ;;
         --max-counterexamples) max_counterexamples="$2"        ; shift 2 ;;
         --branching-allowed)   branching_allowed="$2"          ; shift 2 ;;
         --haskell-backend-arg) haskell_backend_command+=("$2") ; shift 2 ;;
@@ -395,9 +396,9 @@ backend_dir="${backend_dir:-$INSTALL_LIB/$backend}"
 ! $profile_haskell || [[ "$backend" == haskell ]] || fatal "Option --profile-haskell only usable with --backend haskell!"
 [[ $profile_timeout = "0" ]] || $profile_haskell  || fatal "Option --profile-timeout only usable with --profile-haskell!"
 [[ $kore_prof_args = "" ]]   || $profile_haskell  || fatal "Option --kore-prof-args only usable with --profile-haskell!"
-if ${pyk_prove}; then
-    ! ${debugger}        || fatal "Option --pyk-prove not usable with --debugger!"
-    ! ${profile_haskell} || fatal "Option --pyk-prove not usable with --profile-haskell!"
+if ${pyk}; then
+    ! ${debugger}        || fatal "Option --pyk not usable with --debugger!"
+    ! ${profile_haskell} || fatal "Option --pyk not usable with --profile-haskell!"
 fi
 
 # get the run file

--- a/kevm
+++ b/kevm
@@ -61,14 +61,6 @@ run_kevm_pyk() {
 run_kompile() {
     local kompile_opts openssl_root
 
-    if [[ ! -z ${concrete_rules_file} ]]; then
-        if [[ -f ${concrete_rules_file} ]]; then
-            kompile_opts+=(--concrete-rules "$(cat ${concrete_rules_file} | tr '\n' ',')")
-        else
-            fatal "Concrete rules file doesn't exist: ${concrete_rules_file}"
-        fi
-    fi
-
     if ${pyk} && [[ "${backend}" != haskell ]]; then
         fatal "Command kompile with option --pyk only available for --backend haskell."
     fi
@@ -78,6 +70,15 @@ run_kompile() {
     ${pyk} || kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
     ${pyk} || kompile_opts+=( --emit-json )
     kompile_opts+=( --hook-namespaces "JSON KRYPTO BLOCKCHAIN" )
+
+    if [[ ! -z ${concrete_rules_file} ]]; then
+        if [[ -f ${concrete_rules_file} ]]; then
+              ${pyk} || kompile_opts+=(--concrete-rules "$(cat ${concrete_rules_file} | tr '\n' ',')")
+            ! ${pyk} || kompile_opts+=(--concrete-rules-file "${concrete_rules_file}")
+        else
+            fatal "Concrete rules file doesn't exist: ${concrete_rules_file}"
+        fi
+    fi
 
     case "${backend}" in
         haskell)   kompile_opts+=( --md-selector 'k & ! nobytes & ! node')                          ;;

--- a/kevm
+++ b/kevm
@@ -247,17 +247,19 @@ run_interpret() {
     esac
 }
 
+run_kevm_pyk() {
+    execute python3 -m kevm_pyk --definition "${backend_dir}" "$@"
+}
+
 run_solc() {
-    local contract_name json_run_file
+    local contract_name
 
     contract_name="$1" ; shift
-    json_run_file="${run_file}.json"
-
-    execute python3 -m kevm_pyk solc-to-k "${backend_dir}" "${run_file}" "${contract_name}" "$@"
+    run_kevm_pyk solc-to-k "${run_file}" "${contract_name}" "$@"
 }
 
 run_gen_spec() {
-    execute python3 -m kevm_pyk gen-spec-modules "${backend_dir}" "$@"
+    run_kevm_pyk gen-spec-modules "$@"
 }
 
 # Main

--- a/kevm
+++ b/kevm
@@ -5,6 +5,7 @@ shopt -s extglob
 
 debug=false
 profile=false
+verbose=false
 KEVM=kevm
 
 notif() { echo "== ${KEVM}: $*" >&2 ; }
@@ -52,8 +53,8 @@ run_kevm_pyk() {
     local pyk_args
     pyk_args=(--definition "${backend_dir}")
     pyk_args+=(-I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework")
-    ! ${debug} || pyk_args+=(--debug)
-    execute python3 -m kevm_pyk "${pyk_args[@]}" "$@"
+    ! ${verbose} || pyk_args+=(--verbose)
+    execute python3 -m kevm_pyk "$@" "${pyk_args[@]}"
 }
 
 # User Commands
@@ -378,6 +379,7 @@ args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --debug)               debug=true                      ; shift   ;;
+        --verbose)             verbose=true                    ; shift   ;;
         --profile)             profile=true ; args+=("$1")     ; shift   ;;
         --dump)                dump=true                       ; shift   ;;
         --no-unparse)          unparse=false                   ; shift   ;;

--- a/kevm
+++ b/kevm
@@ -61,11 +61,6 @@ run_kevm_pyk() {
 run_kompile() {
     local kompile_opts openssl_root
 
-    kompile_opts=( "${run_file}" --output-definition "${backend_dir}" )
-    kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
-    kompile_opts+=( --hook-namespaces "JSON KRYPTO BLOCKCHAIN"                           )
-    kompile_opts+=( --emit-json                                                          )
-
     if [[ ! -z ${concrete_rules_file} ]]; then
         if [[ -f ${concrete_rules_file} ]]; then
             kompile_opts+=(--concrete-rules "$(cat ${concrete_rules_file} | tr '\n' ',')")
@@ -74,12 +69,22 @@ run_kompile() {
         fi
     fi
 
+    if ${pyk} && [[ "${backend}" != haskell ]]; then
+        fatal "Command kompile with option --pyk only available for --backend haskell."
+    fi
+
+    kompile_opts=( "${run_file}" )
+    ${pyk} || kompile_opts+=( --output-definition "${backend_dir}" )
+    ${pyk} || kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
+    ${pyk} || kompile_opts+=( --emit-json )
+    kompile_opts+=( --hook-namespaces "JSON KRYPTO BLOCKCHAIN" )
+
     case "${backend}" in
-        haskell)   kompile_opts+=( --md-selector 'k & ! nobytes & ! node' --backend haskell)        ;;
-        java)      kompile_opts+=( --md-selector 'k & ! bytes   & ! node' --backend java )          ;;
+        haskell)   kompile_opts+=( --md-selector 'k & ! nobytes & ! node')                          ;;
+        java)      kompile_opts+=( --md-selector 'k & ! bytes   & ! node')                          ;;
         llvm)      kompile_opts+=( --md-selector 'k & ! nobytes & ! node' )                         ;;&
         node)      kompile_opts+=( --md-selector 'k & ! nobytes & ! standalone' --no-llvm-kompile ) ;;&
-        llvm|node) kompile_opts+=( --backend llvm )
+        llvm|node) backend=llvm
                    kompile_opts+=( -ccopt -L${libff_dir}/lib -ccopt -I${libff_dir}/include                       )
                    kompile_opts+=( -ccopt ${plugin_include}/c/plugin_util.cpp                                    )
                    kompile_opts+=( -ccopt ${plugin_include}/c/crypto.cpp                                         )
@@ -97,7 +102,14 @@ run_kompile() {
                    ;;
         *)       fatal "Unknown backend for kompile: ${backend}" ;;
     esac
-    execute kompile "${kompile_opts[@]}" "$@"
+
+    ${pyk} || kompile_opts+=( --backend ${backend} )
+
+    if ${pyk}; then
+        run_kevm_pyk kompile "${kompile_opts[@]}" "$@"
+    else
+        execute kompile "${kompile_opts[@]}" "$@"
+    fi
 }
 
 run_krun() {

--- a/kevm
+++ b/kevm
@@ -48,6 +48,13 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 # Runners
 # -------
 
+run_kevm_pyk() {
+    pyk_args=(--definition "${backend_dir}")
+    pyk_args+=(-I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework")
+    ! ${debug} || pyk_args+=(--debug)
+    execute python3 -m kevm_pyk "${pyk_args[@]}" "$@"
+}
+
 # User Commands
 
 run_kompile() {
@@ -139,10 +146,13 @@ run_prove() {
     bug_report_name="kevm-bug-$(basename "${run_file%-spec.k}")"
     eventlog_name="${run_file}.eventlog"
 
-    proof_args=(--definition "${backend_dir}" "${run_file}")
-    proof_args+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
+    proof_args=("${run_file}")
+    if ! ${pyk_prove}; then
+        proof_args+=(--definition "${backend_dir}")
+        proof_args+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
+        ! ${debug} || proof_args+=(--debug)
+    fi
 
-    ! ${debug}                        || proof_args+=(--debug)
     [[ ! -f ${concrete_rules_file} ]] || proof_args+=(--concrete-rules "$(cat ${concrete_rules_file} | tr '\n' ',')")
 
     case "${backend}" in
@@ -155,7 +165,8 @@ run_prove() {
                  [[ ${#haskell_backend_command[@]} -le 1 ]] || proof_args+=(--haskell-backend-command "${haskell_backend_command[*]}")
                  ;;
 
-        java)    if ${debugger}; then
+        java)    proof_args+=(--format-failures)
+                 if ${debugger}; then
                      omit_cells='<substate> <jumpDests> <program> <code> <callGas> <touchedAccounts> <interimStates> <callStack> <callData> <block> <txOrder> <txPending> <messages>'
                      omit_labels='#mkCall________EVM #callWithCode_________EVM #create_____EVM #mkCreate_____EVM #newAddrCreate2 #finishCodeDeposit___EVM'
                      klab_log="$(basename "${run_file%-spec.k}").k"
@@ -176,10 +187,8 @@ run_prove() {
         timeout -s INT "${profile_timeout}" ${kprove} "${proof_args[@]}" "$@" || true
         execute kore-prof "${eventlog_name}" ${kore_prof_args} > "${eventlog_name}.json"
     else
-        if ${pyk_minimize}; then
-            pyk_args=(${backend_dir} print /dev/stdin --minimize)
-            [[ -z "${pyk_omit_labels}" ]] || pyk_args+=(--omit-labels "${pyk_omit_labels}")
-            execute kprove "${proof_args[@]}" "$@" --output json | kpyk "${pyk_args[@]}"
+        if ${pyk_prove}; then
+            run_kevm_pyk prove "${proof_args[@]}" "$@"
         else
             execute kprove "${proof_args[@]}" "$@"
         fi
@@ -245,10 +254,6 @@ run_interpret() {
         *)      fatal "Bad backend for interpreter: '$backend'"
                 ;;
     esac
-}
-
-run_kevm_pyk() {
-    execute python3 -m kevm_pyk --definition "${backend_dir}" "$@"
 }
 
 run_solc() {
@@ -347,8 +352,7 @@ schedule=LONDON
 chainid=1
 concrete_rules_file=
 verif_module=VERIFICATION
-pyk_minimize=false
-pyk_omit_labels=
+pyk_prove=false
 max_counterexamples=
 branching_allowed=
 haskell_backend_command=(kore-exec)
@@ -359,7 +363,7 @@ kevm_host='127.0.0.1'
 args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --debug)               debug=true   ; args+=("$1")     ; shift   ;;
+        --debug)               debug=true                      ; shift   ;;
         --profile)             profile=true ; args+=("$1")     ; shift   ;;
         --dump)                dump=true                       ; shift   ;;
         --no-unparse)          unparse=false                   ; shift   ;;
@@ -372,8 +376,7 @@ while [[ $# -gt 0 ]]; do
         --definition)          backend_dir="$2"                ; shift 2 ;;
         --concrete-rules-file) concrete_rules_file="$2"        ; shift 2 ;;
         --verif-module)        verif_module="$2"               ; shift 2 ;;
-        --pyk-minimize)        pyk_minimize=true               ; shift   ;;
-        --pyk-omit-labels)     pyk_omit_labels="$2"            ; shift 2 ;;
+        --pyk-prove)           pyk_prove=true                  ; shift   ;;
         --max-counterexamples) max_counterexamples="$2"        ; shift 2 ;;
         --branching-allowed)   branching_allowed="$2"          ; shift 2 ;;
         --haskell-backend-arg) haskell_backend_command+=("$2") ; shift 2 ;;
@@ -392,11 +395,9 @@ backend_dir="${backend_dir:-$INSTALL_LIB/$backend}"
 ! $profile_haskell || [[ "$backend" == haskell ]] || fatal "Option --profile-haskell only usable with --backend haskell!"
 [[ $profile_timeout = "0" ]] || $profile_haskell  || fatal "Option --profile-timeout only usable with --profile-haskell!"
 [[ $kore_prof_args = "" ]]   || $profile_haskell  || fatal "Option --kore-prof-args only usable with --profile-haskell!"
-if ${pyk_minimize}; then
-    ! ${debugger}        || fatal "Option --pyk-minimize not usable with --debugger!"
-    ! ${profile_haskell} || fatal "Option --pyk-minimize not usable with --profile-haskell!"
-elif [[ ! -z ${pyk_omit_labels} ]]; then
-    fatal "Option --pyk-label-omit only usable with --pyk-minimize!"
+if ${pyk_prove}; then
+    ! ${debugger}        || fatal "Option --pyk-prove not usable with --debugger!"
+    ! ${profile_haskell} || fatal "Option --pyk-prove not usable with --profile-haskell!"
 fi
 
 # get the run file

--- a/kevm_pyk/requirements/base.txt
+++ b/kevm_pyk/requirements/base.txt
@@ -1,1 +1,3 @@
 ../deps/k/pyk
+tabulate == 0.8.6
+types-tabulate == 0.8.6

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -45,7 +45,7 @@ def prove(kevm: KEVM, args) -> str:
     prove_args = []
     for inc in args.includes:
         prove_args.extend(['-I', inc])
-    final_state = kevm.prove(spec_file, spec_module_name=spec_module, args=prove_args, haskell_args=[])
+    final_state = kevm.prove(spec_file, spec_module_name=spec_module, args=prove_args, rule_profile=spec_file.with_suffix('.rule-profile'))
     return kevm.pretty_print(final_state)
 
 

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -4,6 +4,7 @@ import sys
 
 from pyk.cli_utils import dir_path, file_path
 
+from .kevm import KEVM
 from .solc_to_k import gen_spec_modules, solc_compile, solc_to_k
 
 
@@ -16,38 +17,46 @@ def main():
         res = solc_compile(args.contract_file)
         print(json.dumps(res))
 
-    elif args.command == 'solc-to-k':
-        res = solc_to_k(
-            definition_dir=args.definition_dir,
-            contract_file=args.contract_file,
-            contract_name=args.contract_name,
-            generate_storage=args.generate_storage,
-        )
-        print(res)
+    elif args.command in ['solc-to-k', 'gen-spec-modules', 'prove']:
 
-    elif args.command == 'gen-spec-modules':
-        res = gen_spec_modules(args.definition_dir, args.spec_module_name)
-        print(res)
+        if 'definition_dir' not in args:
+            raise ValueError(f'Must provide --definition argument to {args.command}!')
+        kevm = KEVM(args['definition_dir'])
+
+        if args.command == 'solc-to-k':
+            res = solc_to_k(kevm, args.contract_file, args.contract_name, args.generate_storage)
+            print(res)
+
+        elif args.command == 'gen-spec-modules':
+            res = gen_spec_modules(kevm, args.spec_module_name)
+            print(res)
+
+        elif args.command == 'prove':
+            res = prove(kevm)
+            print(res)
 
     else:
         assert False
 
 
+def prove(kevm: KEVM) -> str:
+    return ""
+
+
 def create_argument_parser():
     parser = argparse.ArgumentParser(prog='python3 -m kevm_pyk')
+    parser.add_argument('--definition', type=dir_path, dest='definition_dir', help='Path to definition to use.')
     command_parser = parser.add_subparsers(dest='command', required=True)
 
     solc_subparser = command_parser.add_parser('compile', help='Generate combined JSON with solc compilation results.')
     solc_subparser.add_argument('contract_file', type=file_path, help='Path to contract file.')
 
     solc_to_k_subparser = command_parser.add_parser('solc-to-k', help='Output helper K definition for given JSON output from solc compiler.')
-    solc_to_k_subparser.add_argument('definition_dir', type=dir_path, help='Path to definition to use.')
     solc_to_k_subparser.add_argument('contract_file', type=file_path, help='Path to contract file.')
     solc_to_k_subparser.add_argument('contract_name', type=str, help='Name of contract to generate K helpers for.')
     solc_to_k_subparser.add_argument('--no-storage-slots', dest='generate_storage', default=True, action='store_false', help='Do not generate productions and rules for accessing storage slots')
 
     gen_spec_modules_subparser = command_parser.add_parser('gen-spec-modules', help='Output helper K definition for given JSON output from solc compiler.')
-    gen_spec_modules_subparser.add_argument('definition_dir', type=dir_path, help='Path to definition to use.')
     gen_spec_modules_subparser.add_argument('spec_module_name', type=str, help='Name of module containing all the generated specs.')
 
     return parser

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -21,7 +21,7 @@ def main():
 
         if 'definition_dir' not in args:
             raise ValueError(f'Must provide --definition argument to {args.command}!')
-        kevm = KEVM(args['definition_dir'])
+        kevm = KEVM(args.definition_dir)
 
         if args.command == 'solc-to-k':
             res = solc_to_k(kevm, args.contract_file, args.contract_name, args.generate_storage)
@@ -32,21 +32,34 @@ def main():
             print(res)
 
         elif args.command == 'prove':
-            res = prove(kevm)
+            res = prove(kevm, args)
             print(res)
 
     else:
         assert False
 
 
-def prove(kevm: KEVM) -> str:
-    return ""
+def prove(kevm: KEVM, args) -> str:
+    spec_file = args.spec_file
+    spec_module = args.spec_module
+    prove_args = []
+    for inc in args.includes:
+        prove_args.extend(['-I', inc])
+    final_state = kevm.prove(spec_file, spec_module_name=spec_module, args=prove_args, haskell_args=[])
+    return kevm.pretty_print(final_state)
 
 
 def create_argument_parser():
     parser = argparse.ArgumentParser(prog='python3 -m kevm_pyk')
     parser.add_argument('--definition', type=dir_path, dest='definition_dir', help='Path to definition to use.')
+    parser.add_argument('-I', type=str, dest='includes', default=[], action='append', help='Directories to lookup K definitions in.')
+    parser.add_argument('--debug', default=False, action='store_true', help='Print out debugging information.')
+
     command_parser = parser.add_subparsers(dest='command', required=True)
+
+    prove_subparser = command_parser.add_parser('prove', help='Run KEVM proof.')
+    prove_subparser.add_argument('spec_file', type=file_path, help='Path to spec file.')
+    prove_subparser.add_argument('--spec-module', type=str, help='Name of the specification module.')
 
     solc_subparser = command_parser.add_parser('compile', help='Generate combined JSON with solc compilation results.')
     solc_subparser.add_argument('contract_file', type=file_path, help='Path to contract file.')

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -36,6 +36,7 @@ def main():
                 syntax_module_name=args.syntax_module,
                 md_selector=args.md_selector,
                 hook_namespaces=args.hook_namespaces.split(' '),
+                concrete_rules_file=args.concrete_rules_file,
             )
 
         else:
@@ -74,6 +75,7 @@ def create_argument_parser():
     kompile_subparser.add_argument('--syntax-module', type=str, help='Name of the syntax module.')
     kompile_subparser.add_argument('--md-selector', type=str, help='Code selector expression to use when reading markdown.')
     kompile_subparser.add_argument('--hook-namespaces', type=str, help='Hook namespaces. What more can I say?')
+    kompile_subparser.add_argument('--concrete-rules-file', type=str, help='List of rules to only evaluate if arguments are fully concrete.')
 
     prove_subparser = command_parser.add_parser('prove', help='Run KEVM proof.')
     prove_subparser.add_argument('spec_file', type=file_path, help='Path to spec file.')

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -1,11 +1,16 @@
 import argparse
 import json
+import logging
 import sys
+from typing import Final
 
-from pyk.cli_utils import dir_path, file_path
+from pyk.cli_utils import file_path
 
 from .kevm import KEVM
 from .solc_to_k import gen_spec_modules, solc_compile, solc_to_k
+from .utils import add_include_arg
+
+_LOGGER: Final = logging.getLogger(__name__)
 
 
 def main():
@@ -17,45 +22,58 @@ def main():
         res = solc_compile(args.contract_file)
         print(json.dumps(res))
 
-    elif args.command in ['solc-to-k', 'gen-spec-modules', 'prove']:
+    elif args.command in ['solc-to-k', 'gen-spec-modules', 'kompile', 'prove']:
 
         if 'definition_dir' not in args:
             raise ValueError(f'Must provide --definition argument to {args.command}!')
-        kevm = KEVM(args.definition_dir)
 
-        if args.command == 'solc-to-k':
-            res = solc_to_k(kevm, args.contract_file, args.contract_name, args.generate_storage)
-            print(res)
+        if args.command == 'kompile':
+            kevm = KEVM.kompile(
+                args.definition_dir,
+                args.main_file,
+                includes=args.includes,
+                main_module_name=args.main_module,
+                syntax_module_name=args.syntax_module,
+                md_selector=args.md_selector,
+                hook_namespaces=args.hook_namespaces.split(' '),
+            )
 
-        elif args.command == 'gen-spec-modules':
-            res = gen_spec_modules(kevm, args.spec_module_name)
-            print(res)
+        else:
+            kevm = KEVM(args.definition_dir)
 
-        elif args.command == 'prove':
-            res = prove(kevm, args)
-            print(res)
+            if args.command == 'solc-to-k':
+                res = solc_to_k(kevm, args.contract_file, args.contract_name, args.generate_storage)
+                print(res)
+
+            elif args.command == 'gen-spec-modules':
+                res = gen_spec_modules(kevm, args.spec_module_name)
+                print(res)
+
+            elif args.command == 'prove':
+                spec_file = args.spec_file
+                spec_module = args.spec_module
+                prove_args = add_include_arg(args.includes)
+                final_state = kevm.prove(spec_file, spec_module_name=spec_module, args=prove_args, rule_profile=spec_file.with_suffix('.rule-profile'))
+                print(kevm.pretty_print(final_state) + '\n')
 
     else:
         assert False
 
 
-def prove(kevm: KEVM, args) -> str:
-    spec_file = args.spec_file
-    spec_module = args.spec_module
-    prove_args = []
-    for inc in args.includes:
-        prove_args.extend(['-I', inc])
-    final_state = kevm.prove(spec_file, spec_module_name=spec_module, args=prove_args, rule_profile=spec_file.with_suffix('.rule-profile'))
-    return kevm.pretty_print(final_state)
-
-
 def create_argument_parser():
     parser = argparse.ArgumentParser(prog='python3 -m kevm_pyk')
-    parser.add_argument('--definition', type=dir_path, dest='definition_dir', help='Path to definition to use.')
+    parser.add_argument('--definition', type=str, dest='definition_dir', help='Path to definition to use.')
     parser.add_argument('-I', type=str, dest='includes', default=[], action='append', help='Directories to lookup K definitions in.')
     parser.add_argument('--debug', default=False, action='store_true', help='Print out debugging information.')
 
     command_parser = parser.add_subparsers(dest='command', required=True)
+
+    kompile_subparser = command_parser.add_parser('kompile', help='Kompile KEVM specification.')
+    kompile_subparser.add_argument('main_file', type=file_path, help='Path to file with main module.')
+    kompile_subparser.add_argument('--main-module', type=str, help='Name of the main module.')
+    kompile_subparser.add_argument('--syntax-module', type=str, help='Name of the syntax module.')
+    kompile_subparser.add_argument('--md-selector', type=str, help='Code selector expression to use when reading markdown.')
+    kompile_subparser.add_argument('--hook-namespaces', type=str, help='Hook namespaces. What more can I say?')
 
     prove_subparser = command_parser.add_parser('prove', help='Run KEVM proof.')
     prove_subparser.add_argument('spec_file', type=file_path, help='Path to spec file.')

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -9,7 +9,7 @@ from .utils import build_empty_configuration_cell
 class KEVM(KProve):
 
     def __init__(self, kompiled_directory, main_file_name=None, use_directory=None):
-        super().__init__(kompiled_directory, main_file_name=None, use_directory=use_directory)
+        super().__init__(kompiled_directory, main_file_name=main_file_name, use_directory=use_directory)
         KEVM._patch_symbol_table(self.symbol_table)
 
     def empty_config(self, top_cell: KSort = KSort('GeneratedTopCell')) -> KInner:

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -11,7 +11,7 @@ from pyk.kastManip import flattenLabel, getCell
 from pyk.ktool import KProve, paren
 from pyk.prelude import intToken, stringToken
 
-from .utils import add_include_arg, build_empty_configuration_cell
+from .utils import add_include_arg, build_empty_config_cell
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ class KEVM(KProve):
         KEVM._patch_symbol_table(self.symbol_table)
 
     def empty_config(self, top_cell: KSort = KSort('GeneratedTopCell')) -> KInner:
-        return build_empty_configuration_cell(self.definition, top_cell)
+        return build_empty_config_cell(self.definition, top_cell)
 
     @staticmethod
     def kompile(

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -1,0 +1,40 @@
+from typing import Any, Dict
+
+from pyk.kast import KInner, KSort
+from pyk.ktool import KProve, paren
+
+from .utils import build_empty_configuration_cell
+
+
+class KEVM(KProve):
+
+    def __init__(self, kompiled_directory, main_file_name=None, use_directory=None):
+        super().__init__(kompiled_directory, main_file_name=None, use_directory=use_directory)
+        KEVM._patch_symbol_table(self.symbol_table)
+
+    def empty_config(self, top_cell: KSort = KSort('GeneratedTopCell')) -> KInner:
+        return build_empty_configuration_cell(self.definition, top_cell)
+
+    @staticmethod
+    def _patch_symbol_table(symbol_table: Dict[str, Any]) -> None:
+        symbol_table['_orBool_']                                      = paren(symbol_table['_orBool_'])                                     # noqa
+        symbol_table['_andBool_']                                     = paren(symbol_table['_andBool_'])                                    # noqa
+        symbol_table['_impliesBool_']                                 = paren(symbol_table['_impliesBool_'])                                # noqa
+        symbol_table['notBool_']                                      = paren(symbol_table['notBool_'])                                     # noqa
+        symbol_table['_/Int_']                                        = paren(symbol_table['_/Int_'])                                       # noqa
+        symbol_table['#Or']                                           = paren(symbol_table['#Or'])                                          # noqa
+        symbol_table['#And']                                          = paren(symbol_table['#And'])                                         # noqa
+        symbol_table['#Implies']                                      = paren(symbol_table['#Implies'])                                     # noqa
+        symbol_table['_Set_']                                         = paren(symbol_table['_Set_'])                                        # noqa
+        symbol_table['_|->_']                                         = paren(symbol_table['_|->_'])                                        # noqa
+        symbol_table['_Map_']                                         = paren(lambda m1, m2: m1 + '\n' + m2)                                # noqa
+        symbol_table['_AccountCellMap_']                              = paren(lambda a1, a2: a1 + '\n' + a2)                                # noqa
+        symbol_table['AccountCellMapItem']                            = lambda k, v: v                                                      # noqa
+        symbol_table['_[_:=_]_EVM-TYPES_Memory_Memory_Int_ByteArray'] = lambda m, k, v: m + ' [ '  + k + ' := (' + v + '):ByteArray ]'      # noqa
+        symbol_table['_[_.._]_EVM-TYPES_ByteArray_ByteArray_Int_Int'] = lambda m, s, w: '(' + m + ' [ ' + s + ' .. ' + w + ' ]):ByteArray'  # noqa
+        symbol_table['_<Word__EVM-TYPES_Int_Int_Int']                 = paren(lambda a1, a2: '(' + a1 + ') <Word ('  + a2 + ')')            # noqa
+        symbol_table['_>Word__EVM-TYPES_Int_Int_Int']                 = paren(lambda a1, a2: '(' + a1 + ') >Word ('  + a2 + ')')            # noqa
+        symbol_table['_<=Word__EVM-TYPES_Int_Int_Int']                = paren(lambda a1, a2: '(' + a1 + ') <=Word (' + a2 + ')')            # noqa
+        symbol_table['_>=Word__EVM-TYPES_Int_Int_Int']                = paren(lambda a1, a2: '(' + a1 + ') >=Word (' + a2 + ')')            # noqa
+        symbol_table['_==Word__EVM-TYPES_Int_Int_Int']                = paren(lambda a1, a2: '(' + a1 + ') ==Word (' + a2 + ')')            # noqa
+        symbol_table['_s<Word__EVM-TYPES_Int_Int_Int']                = paren(lambda a1, a2: '(' + a1 + ') s<Word (' + a2 + ')')            # noqa

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -1,9 +1,86 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
-from pyk.kast import KInner, KSort
+from pyk.kast import KApply, KInner, KSort
+from pyk.kastManip import flattenLabel, getCell
 from pyk.ktool import KProve, paren
+from pyk.prelude import intToken, stringToken
 
 from .utils import build_empty_configuration_cell
+
+# KEVM helpers
+
+
+def pow256():
+    return KApply('pow256_EVM-TYPES_Int', [])
+
+
+def rangeUInt160(i: KInner) -> KApply:
+    return KApply('#rangeUInt(_,_)_EVM-TYPES_Bool_Int_Int', [intToken(160), i])
+
+
+def rangeUInt256(i: KInner) -> KApply:
+    return KApply('#rangeUInt(_,_)_EVM-TYPES_Bool_Int_Int', [intToken(256), i])
+
+
+def rangeAddress(i: KInner) -> KApply:
+    return KApply('#rangeAddress(_)_EVM-TYPES_Bool_Int', [i])
+
+
+def rangeBool(i: KInner) -> KApply:
+    return KApply('#rangeBool(_)_EVM-TYPES_Bool_Int', [i])
+
+
+def sizeByteArray(ba: KInner) -> KApply:
+    return KApply('#sizeByteArray(_)_EVM-TYPES_Int_ByteArray', [ba])
+
+
+def inf_gas(g: KInner) -> KApply:
+    return KApply('infGas', [g])
+
+
+def computeValidJumpDests(p: KInner) -> KApply:
+    return KApply('#computeValidJumpDests(_)_EVM_Set_ByteArray', [p])
+
+
+def binRuntime(c: KInner) -> KApply:
+    return KApply('#binRuntime', [c])
+
+
+def abiCallData(n: str, args: List[KInner]):
+    token: KInner = stringToken(n)
+    return KApply('#abiCallData', [token] + args)
+
+
+def abiAddress(a: KInner) -> KApply:
+    return KApply('#address(_)_EVM-ABI_TypedArg_Int', [a])
+
+
+def abiBool(b: KInner) -> KApply:
+    return KApply('#bool(_)_EVM-ABI_TypedArg_Int', [b])
+
+
+def emptyTypedArgs() -> KApply:
+    return KApply('.List{"_,__EVM-ABI_TypedArgs_TypedArg_TypedArgs"}_TypedArgs')
+
+
+def bytesAppend(b1: KInner, b2: KInner) -> KApply:
+    return KApply('_++__EVM-TYPES_ByteArray_ByteArray_ByteArray', [b1, b2])
+
+
+def kevm_account_cell(id: KInner, balance: KInner, code: KInner, storage: KInner, origStorage: KInner, nonce: KInner) -> KApply:
+    return KApply('<account>', [KApply('<acctID>', [id]),
+                                KApply('<balance>', [balance]),
+                                KApply('<code>', [code]),
+                                KApply('<storage>', [storage]),
+                                KApply('<origStorage>', [origStorage]),
+                                KApply('<nonce>', [nonce])])
+
+
+def kevm_wordstack_len(constrainedTerm: KInner) -> int:
+    return len(flattenLabel('_:__EVM-TYPES_WordStack_Int_WordStack', getCell(constrainedTerm, 'WORDSTACK_CELL')))
+
+
+# KEVM class
 
 
 class KEVM(KProve):

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -24,7 +24,7 @@ from pyk.kast import (
     KToken,
     KVariable,
 )
-from pyk.kastManip import buildRule, substitute
+from pyk.kastManip import buildRule, remove_generated_cells, substitute
 from pyk.prelude import intToken, stringToken
 from pyk.utils import intersperse
 
@@ -44,7 +44,7 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
 
 
 def gen_claims_for_contract(kevm: KEVM, contract_name: str) -> List[KClaim]:
-    empty_config = kevm.empty_config()
+    empty_config = remove_generated_cells(kevm.empty_config())
     program = KApply('binRuntime', [KApply('contract_' + contract_name)])
     account_cell = kevm_account_cell(KVariable('ACCT_ID'), KVariable('ACCT_BALANCE'), program, KVariable('ACCT_STORAGE'), KVariable('ACCT_ORIGSTORAGE'), KVariable('ACCT_NONCE'))
     init_subst = {

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -153,6 +153,7 @@ def solc_to_k(kevm: KEVM, contract_file: Path, contract_name: str, generate_stor
     kevm.symbol_table['rangeUInt']      = lambda n, t: '#rangeUInt(' + n + ', ' + t + ')'                                           # noqa
     kevm.symbol_table['rangeSInt']      = lambda n, t: '#rangeSInt(' + n + ', ' + t + ')'                                           # noqa
     kevm.symbol_table['binRuntime']     = lambda s: '#binRuntime(' + s + ')'                                                        # noqa
+    kevm.symbol_table['abi_selector']   = lambda s: 'selector(' + s + ')'                                                           # noqa
     kevm.symbol_table[contract_name]    = lambda: contract_name                                                                     # noqa
 
     return kevm.pretty_print(binRuntimeDefinition) + '\n'

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -28,8 +28,8 @@ from pyk.kastManip import buildRule, substitute
 from pyk.prelude import intToken, stringToken
 from pyk.utils import intersperse
 
-from .kevm import KEVM
-from .utils import abstract_cell_vars, infGas, kevmAccountCell
+from .kevm import KEVM, inf_gas, kevm_account_cell
+from .utils import abstract_cell_vars
 
 
 def solc_compile(contract_file: Path) -> Dict[str, Any]:
@@ -46,7 +46,7 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
 def gen_claims_for_contract(kevm: KEVM, contract_name: str) -> List[KClaim]:
     empty_config = kevm.empty_config()
     program = KApply('binRuntime', [KApply('contract_' + contract_name)])
-    account_cell = kevmAccountCell(KVariable('ACCT_ID'), KVariable('ACCT_BALANCE'), program, KVariable('ACCT_STORAGE'), KVariable('ACCT_ORIGSTORAGE'), KVariable('ACCT_NONCE'))
+    account_cell = kevm_account_cell(KVariable('ACCT_ID'), KVariable('ACCT_BALANCE'), program, KVariable('ACCT_STORAGE'), KVariable('ACCT_ORIGSTORAGE'), KVariable('ACCT_NONCE'))
     init_subst = {
         'MODE_CELL': KToken('NORMAL', 'Mode'),
         'SCHEDULE_CELL': KApply('LONDON_EVM'),
@@ -61,7 +61,7 @@ def gen_claims_for_contract(kevm: KEVM, contract_name: str) -> List[KClaim]:
         'MEMORYUSED_CELL': intToken(0),
         'WORDSTACK_CELL': KApply('.WordStack_EVM-TYPES_WordStack'),
         'PC_CELL': intToken(0),
-        'GAS_CELL': infGas(KVariable('VGAS')),
+        'GAS_CELL': inf_gas(KVariable('VGAS')),
         'K_CELL': KSequence([KApply('#execute_EVM_KItem'), KVariable('CONTINUATION')]),
         'ACCOUNTS_CELL': KApply('_AccountCellMap_', [account_cell, KVariable('ACCOUNTS')]),
     }

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -8,6 +8,10 @@ from pyk.kastManip import (
 )
 
 
+def add_include_arg(includes):
+    return [arg for include in includes for arg in ['-I', include]]
+
+
 def abstract_cell_vars(cterm):
     state, _ = splitConfigAndConstraints(cterm)
     config, subst = splitConfigFrom(state)

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -44,7 +44,7 @@ def get_label_for_cell_sorts(definition, sort):
     return productions[0].klabel
 
 
-def build_empty_configuration_cell(definition, sort):
+def build_empty_config_cell(definition, sort):
     label = get_label_for_cell_sorts(definition, sort)
     production = get_production_for_klabel(definition, label)
     args = []
@@ -54,7 +54,7 @@ def build_empty_configuration_cell(definition, sort):
         if type(p_item) is KNonTerminal:
             num_nonterminals += 1
             if p_item.sort.name.endswith('Cell'):
-                args.append(build_empty_configuration_cell(definition, p_item.sort))
+                args.append(build_empty_config_cell(definition, p_item.sort))
             else:
                 num_freshvars += 1
                 args.append(KVariable(sort.name[0:-4].upper() + '_CELL'))

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -1,99 +1,11 @@
-from typing import List
-
-from pyk.kast import (
-    KApply,
-    KInner,
-    KNonTerminal,
-    KTerminal,
-    KVariable,
-    flattenLabel,
-)
+from pyk.kast import KApply, KNonTerminal, KTerminal, KVariable
 from pyk.kastManip import (
     abstractTermSafely,
-    getCell,
     isAnonVariable,
     splitConfigAndConstraints,
     splitConfigFrom,
     substitute,
 )
-from pyk.prelude import intToken, stringToken
-
-
-def pow256():
-    return KApply('pow256_EVM-TYPES_Int', [])
-
-
-def rangeUInt160(i: KInner) -> KApply:
-    return KApply('#rangeUInt(_,_)_EVM-TYPES_Bool_Int_Int', [intToken(160), i])
-
-
-def rangeUInt256(i: KInner) -> KApply:
-    return KApply('#rangeUInt(_,_)_EVM-TYPES_Bool_Int_Int', [intToken(256), i])
-
-
-def rangeAddress(i: KInner) -> KApply:
-    return KApply('#rangeAddress(_)_EVM-TYPES_Bool_Int', [i])
-
-
-def rangeBool(i: KInner) -> KApply:
-    return KApply('#rangeBool(_)_EVM-TYPES_Bool_Int', [i])
-
-
-def sizeByteArray(ba: KInner) -> KApply:
-    return KApply('#sizeByteArray(_)_EVM-TYPES_Int_ByteArray', [ba])
-
-
-def infGas(g: KInner) -> KApply:
-    return KApply('infGas', [g])
-
-
-def computeValidJumpDests(p: KInner) -> KApply:
-    return KApply('#computeValidJumpDests(_)_EVM_Set_ByteArray', [p])
-
-
-def binRuntime(c: KInner) -> KApply:
-    return KApply('#binRuntime', [c])
-
-
-def abiCallData(n: str, args: List[KInner]):
-    token: KInner = stringToken(n)
-    return KApply('#abiCallData', [token] + args)
-
-
-def abiAddress(a: KInner) -> KApply:
-    return KApply('#address(_)_EVM-ABI_TypedArg_Int', [a])
-
-
-def abiBool(b: KInner) -> KApply:
-    return KApply('#bool(_)_EVM-ABI_TypedArg_Int', [b])
-
-
-def emptyTypedArgs() -> KApply:
-    return KApply('.List{"_,__EVM-ABI_TypedArgs_TypedArg_TypedArgs"}_TypedArgs')
-
-
-def bytesAppend(b1: KInner, b2: KInner) -> KApply:
-    return KApply('_++__EVM-TYPES_ByteArray_ByteArray_ByteArray', [b1, b2])
-
-
-def kevmAccountCell(
-    id: KInner,
-    balance: KInner,
-    code: KInner,
-    storage: KInner,
-    origStorage: KInner,
-    nonce: KInner,
-) -> KApply:
-    return KApply('<account>', [KApply('<acctID>', [id]),
-                                KApply('<balance>', [balance]),
-                                KApply('<code>', [code]),
-                                KApply('<storage>', [storage]),
-                                KApply('<origStorage>', [origStorage]),
-                                KApply('<nonce>', [nonce])])
-
-
-def kevmWordStackLen(constrainedTerm: KInner) -> int:
-    return len(flattenLabel('_:__EVM-TYPES_WordStack_Int_WordStack', getCell(constrainedTerm, 'WORDSTACK_CELL')))
 
 
 def abstract_cell_vars(cterm):


### PR DESCRIPTION
~Blocked on: https://github.com/runtimeverification/k/pull/2624~

This adds an argument `--pyk` which switches to use `pyk` to do proving/kompiling with.

- A new class `KEVM` is factored out, which has function `_patch_symbol_table(...)` and `empty_config(...)` built in.
- Option `--pyk` uses `kevm_pyk` to do proving, should pass a test on CI, and produce rule profile reports.
- Option `--pyk` uses `kevm_pyk` to do kompiling, and should pass a test on CI.
- `kevm_*` helper methods are moved to `kevm.py` file.
- Adds a test of `--pyk` for both `kompile` and `kprove` by building the Haskell backend and Bihu proofs definitions using kevm_pyk, and checking that the Bihu functional spec correctly generates a rule profile with --pyk.

This enables using kevm_pyk library directly for kprove/kompile in the summarizer.