### PR TITLE
non-negative chop as smt lemma

### DIFF
--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -17,7 +17,7 @@ module LEMMAS
 
     // chop range & simplification
     rule chop(I) => I requires #rangeUInt( 256 , I ) [simplification]
-    rule 0 <=Int chop(_V)             => true        [simplification]
+    rule 0 <=Int chop(_V)             => true        [simplification, smt-lemma]
     rule         chop(_V) <Int pow256 => true        [simplification]
 
   // ########################


### PR DESCRIPTION
By making the rewrite rule which says that `chop` is non-negative an SMT lemma, the tests [forwardToHotWallet-success-1-spec.k](https://github.com/runtimeverification/evm-semantics/blob/master/tests/specs/bihu/forwardToHotWallet-success-1-spec.k) and [forwardToHotWallet-success-2-spec.k](https://github.com/runtimeverification/evm-semantics/blob/master/tests/specs/bihu/forwardToHotWallet-success-2-spec.k) now pass.