### PR TITLE
additional simplifications for buffers and buffer concatenation

### DIFF
--- a/tests/specs/bihu/verification.k
+++ b/tests/specs/bihu/verification.k
@@ -65,7 +65,7 @@ module VERIFICATION
   // #accumulatedReleasedTokens
   // ###############################
 
-    syntax Int ::= "#accumulatedReleasedTokens" "(" Int "," Int "," Int "," Int ")"  [function]
+    syntax Int ::= "#accumulatedReleasedTokens" "(" Int "," Int "," Int "," Int ")"  [function, no-evaluators]
  // -------------------------------------------------------------------------------------------
     // proved manually
     rule COLLECTED <=Int @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START))                => true  requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3 [simplification]

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -179,11 +179,27 @@ module LEMMAS-MCD-COMMON
     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ])  requires 0 <Int WIDTH [simplification]
     rule (_  : WS) [ START .. WIDTH ] => WS [ START -Int 1 .. WIDTH ]     requires 0 <Int START [simplification]
 
-    // ### cat-exhaustiveness
-
     rule WS [ START .. WIDTH ] [ 0 .. WIDTH' ]  => WS [ START .. WIDTH' ]  requires WIDTH' <=Int WIDTH [simplification]
 
+    // Buffer equality specialized to buffer length 32
+    rule { #buf(32, BY:Int):ByteArray #Equals #buf(32, BZ:Int):ByteArray } => { BY #Equals BZ }
+         requires #rangeUInt(256, BY) andBool #rangeUInt(256, BZ) [simplification]
+
+    // ### cat-exhaustiveness
+
     rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 ) [simplification]
+
+    rule { BA1:ByteArray ++ BA2:ByteArray #Equals BA1:ByteArray ++ BA3:ByteArray } => { BA2 #Equals BA3 } [simplification]
+
+    // Note: simplifications below are specialized to buffer length 32
+
+    rule { #buf(32, BY:Int):ByteArray ++ BA1:ByteArray #Equals #buf(32, BZ:Int):ByteArray ++ BA2:ByteArray } => 
+         { BY #Equals BZ } #And { BA1 #Equals BA2 } 
+         requires #rangeUInt(256, BY) andBool #rangeUInt(256, BZ) [simplification]
+
+    rule { #buf(32, BY:Int):ByteArray #Equals #buf(32, BZ:Int):ByteArray ++ BA2:ByteArray } => 
+         { BY #Equals BZ } #And { .ByteArray #Equals BA2 } 
+         requires #rangeUInt(256, BY) andBool #rangeUInt(256, BZ) [simplification]
 
   // ########################
   // Word Reasoning


### PR DESCRIPTION
Several basic simplifications for buffers and buffer concatenation that allow [end-cash-pass-rough-spec.k](https://github.com/runtimeverification/evm-semantics/blob/master/tests/specs/mcd/end-cash-pass-rough-spec.k) and
[end-pack-pass-rough-spec.k](https://github.com/runtimeverification/evm-semantics/blob/master/tests/specs/mcd/end-pack-pass-rough-spec.k) to pass: