### PR TITLE
Allowing passing through environment to KEVM.kompile

### DIFF
--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -110,6 +110,7 @@ class KEVM(KProve):
         md_selector: Optional[str] = None,
         hook_namespaces: Optional[List[str]] = None,
         concrete_rules_file: Optional[Path] = None,
+        env: Optional[Mapping[str, str]] = None,
     ) -> 'KEVM':
         command = ['kompile', '--output-definition', str(definition_dir), str(main_file_name)]
         command += ['--emit-json', '--backend', 'haskell']
@@ -123,7 +124,7 @@ class KEVM(KProve):
                 concrete_rules = ','.join(crf.read().split('\n'))
                 command += ['--concrete-rules', concrete_rules]
         try:
-            run_process(command, _LOGGER)
+            run_process(command, _LOGGER, env=env)
         except CalledProcessError as err:
             sys.stderr.write(f'\nkompile stdout:\n{err.stdout}\n')
             sys.stderr.write(f'\nkompile stderr:\n{err.stderr}\n')

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -3,7 +3,7 @@ import os
 import sys
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Any, Dict, Final, List, Optional
+from typing import Any, Dict, Final, List, Mapping, Optional
 
 from pyk.cli_utils import run_process
 from pyk.kast import KApply, KInner, KSort


### PR DESCRIPTION
This allows setting the environment on the call to `kompile` from `KEVM.kompile`.