### PR TITLE
Upgrades for better kevm_pyk user experience

### DIFF
--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -139,6 +139,9 @@ class KEVM(KProve):
         symbol_table['_impliesBool_']                                 = paren(symbol_table['_impliesBool_'])                                # noqa
         symbol_table['notBool_']                                      = paren(symbol_table['notBool_'])                                     # noqa
         symbol_table['_/Int_']                                        = paren(symbol_table['_/Int_'])                                       # noqa
+        symbol_table['_*Int_']                                        = paren(symbol_table['_*Int_'])                                       # noqa
+        symbol_table['_-Int_']                                        = paren(symbol_table['_-Int_'])                                       # noqa
+        symbol_table['_+Int_']                                        = paren(symbol_table['_+Int_'])                                       # noqa
         symbol_table['#Or']                                           = paren(symbol_table['#Or'])                                          # noqa
         symbol_table['#And']                                          = paren(symbol_table['#And'])                                         # noqa
         symbol_table['#Implies']                                      = paren(symbol_table['#Implies'])                                     # noqa

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -1,6 +1,6 @@
 from pyk.kast import KApply, KNonTerminal, KTerminal, KVariable
 from pyk.kastManip import (
-    abstractTermSafely,
+    abstract_term_safely,
     isAnonVariable,
     splitConfigAndConstraints,
     splitConfigFrom,
@@ -17,7 +17,7 @@ def abstract_cell_vars(cterm):
     config, subst = splitConfigFrom(state)
     for s in subst:
         if type(subst[s]) is KVariable and not isAnonVariable(subst[s]):
-            subst[s] = abstractTermSafely(KVariable('_'), baseName=s)
+            subst[s] = abstract_term_safely(KVariable('_'), base_name=s)
     return substitute(config, subst)
 
 


### PR DESCRIPTION
- Add parenthesis around unparsed integer operations.
- Rename `abstractTermSafely => abstract_term_safely`