### PR TITLE
Include INFINITE-GAS into EDSL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,14 +177,14 @@ kevm_files := abi.md              \
               evm-types.md        \
               evm-node.md         \
               hashed-locations.md \
+              infinite-gas.md     \
               json-rpc.md         \
               network.md          \
               optimizations.md    \
               serialization.md    \
               state-utils.md
 
-kevm_lemmas := infinite-gas.k       \
-               lemmas.k             \
+kevm_lemmas := lemmas.k             \
                int-simplification.k \
                erc20/evm-symbolic.k \
                mcd/bin_runtime.k    \

--- a/edsl.md
+++ b/edsl.md
@@ -10,6 +10,7 @@ The notations are inspired by the production compilers of the smart contract lan
 requires "buf.md"
 requires "hashed-locations.md"
 requires "abi.md"
+requires "infinite-gas.md"
 requires "optimizations.md"
 
 module EDSL
@@ -17,6 +18,7 @@ module EDSL
     imports HASHED-LOCATIONS
     imports EVM-ABI
     imports EVM-OPTIMIZATIONS
+    imports INFINITE-GAS
 endmodule
 
 module BIN-RUNTIME

--- a/infinite-gas.md
+++ b/infinite-gas.md
@@ -26,11 +26,6 @@ module INFINITE-GAS-JAVA [kast]
     //       rules in lemmas.k by organizing them into int-simplification.k
     rule C1 +Int S2 => S2 +Int C1 requires #isConcrete(C1) andBool notBool #isConcrete(S2) [simplification]
 
-    rule S1 +Int (S2 +Int I3) => (S1 +Int S2) +Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
-    rule S1 +Int (S2 -Int I3) => (S1 +Int S2) -Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
-    rule S1 -Int (S2 +Int I3) => (S1 -Int S2) -Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
-    rule S1 -Int (S2 -Int I3) => (S1 -Int S2) +Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
-
     rule S1 +Int (C2 -Int S3) => (S1 -Int S3) +Int C2 requires #isConcrete(C2) andBool (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S3)) [simplification]
     rule S1 -Int (C2 -Int S3) => (S1 +Int S3) -Int C2 requires #isConcrete(C2) andBool (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S3)) [simplification]
 
@@ -43,6 +38,19 @@ module INFINITE-GAS-JAVA [kast]
     rule (S1 +Int C2) -Int C3 => S1 +Int (C2 -Int C3) requires #isConcrete(C2) andBool #isConcrete(C3) andBool notBool #isConcrete(S1) [simplification]
     rule (S1 -Int C2) +Int C3 => S1 +Int (C3 -Int C2) requires #isConcrete(C2) andBool #isConcrete(C3) andBool notBool #isConcrete(S1) [simplification]
     rule (S1 -Int C2) -Int C3 => S1 -Int (C2 +Int C3) requires #isConcrete(C2) andBool #isConcrete(C3) andBool notBool #isConcrete(S1) [simplification]
+endmodule
+
+module INFINITE-GAS-JAVA-EXTRA [kast]
+    imports INFINITE-GAS-JAVA
+
+    // These lemmas conflict with a lemma in `bihu` proofs about `chop(I1 + (I2 - I3))`.
+    // Because these are just for Java backend, we pull them out and re-include them where they are needed (`mcd` and `benchmarks`).
+    // When Java backend is removed, we can delete this module anyway.
+
+    rule S1 +Int (S2 +Int I3) => (S1 +Int S2) +Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
+    rule S1 +Int (S2 -Int I3) => (S1 +Int S2) -Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
+    rule S1 -Int (S2 +Int I3) => (S1 -Int S2) -Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
+    rule S1 -Int (S2 -Int I3) => (S1 -Int S2) +Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
 endmodule
 
 module INFINITE-GAS-HASKELL [kore]

--- a/infinite-gas.md
+++ b/infinite-gas.md
@@ -1,17 +1,16 @@
-requires "evm.md"
-requires "./int-simplification.k"
+KEVM Infinite Gas
+=================
 
- //
- // Infinite Gas
- // Here we use the construct `#gas` to represent positive infinity, while tracking the gas formula through execution.
- // This allows (i) computing final gas used, and (ii) never stopping because of out-of-gas.
- // Note that the argument to `#gas(_)` is just metadata tracking the current gas usage, and is not meant to be compared to other values.
- // As such, any `#gas(G)` and `#gas(G')` are the _same_ positive infinite, regardless of the values `G` and `G'`.
- // In particular, this means that `#gas(_) <Int #gas(_) => false`, and `#gas(_) <=Int #gas(_) => true`, regardless of the values contained in the `#gas(_)`.
- //
+Here we use the construct `#gas` to represent positive infinity, while tracking the gas formula through execution.
+This allows (i) computing final gas used, and (ii) never stopping because of out-of-gas.
+Note that the argument to `#gas(_)` is just metadata tracking the current gas usage, and is not meant to be compared to other values.
+As such, any `#gas(G)` and `#gas(G')` are the _same_ positive infinite, regardless of the values `G` and `G'`.
+In particular, this means that `#gas(_) <Int #gas(_) => false`, and `#gas(_) <=Int #gas(_) => true`, regardless of the values contained in the `#gas(_)`.
+
+```k
+requires "evm.md"
 
 module INFINITE-GAS
-    imports INT-SIMPLIFICATION
     imports INFINITE-GAS-JAVA
     imports INFINITE-GAS-HASKELL
 endmodule
@@ -148,3 +147,4 @@ module INFINITE-GAS-COMMON
     rule Csload(_, _) <=Int #gas(_) => true  [simplification]
 
 endmodule
+```

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -82,7 +82,8 @@ def main():
             elif args.command == 'foundry-to-k':
                 path_glob = str(args.out) + '/**/*.json'
                 modules: List[KFlatModule] = []
-                for json_file in glob.glob(path_glob):
+                # Must sort to get consistent output order on different platforms.
+                for json_file in sorted(glob.glob(path_glob)):
                     _LOGGER.info(f'Processing contract file: {json_file}')
                     contract_name = json_file.split('/')[-1]
                     contract_name = contract_name[0:-5] if contract_name.endswith('.json') else contract_name

--- a/tests/gen-spec/verification.k
+++ b/tests/gen-spec/verification.k
@@ -1,5 +1,4 @@
 requires "lemmas/lemmas.k"
-requires "lemmas/infinite-gas.k"
 
 requires "dai-bin-runtime.k"
 requires "daijoin-bin-runtime.k"

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -24,6 +24,7 @@ module VERIFICATION
     imports VERIFICATION-COMMON
     imports VERIFICATION-JAVA
     imports VERIFICATION-HASKELL
+    imports INFINITE-GAS-JAVA-EXTRA
 
   // ########################
   // Map Reasoning

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -1,9 +1,7 @@
-requires "../infinite-gas.k"
 requires "../lemmas.k"
 
 module VERIFICATION-COMMON
     imports LEMMAS
-    imports INFINITE-GAS
 
   // ########################
   // Ecrecover

--- a/tests/specs/erc20/verification.k
+++ b/tests/specs/erc20/verification.k
@@ -1,13 +1,11 @@
 requires "edsl.md"
 requires "evm-symbolic.k"
-requires "../infinite-gas.k"
 requires "../lemmas.k"
 
 module VERIFICATION
     imports VERIFICATION-JAVA
     imports VERIFICATION-HASKELL
     imports LEMMAS
-    imports INFINITE-GAS
 
 endmodule
 

--- a/tests/specs/examples/erc20-spec.md
+++ b/tests/specs/examples/erc20-spec.md
@@ -5,7 +5,6 @@ ERC20-ish Verification
 requires "edsl.md"
 requires "optimizations.md"
 requires "lemmas/lemmas.k"
-requires "lemmas/infinite-gas.k"
 ```
 
 Solidity Code
@@ -28,7 +27,6 @@ requires "erc20-bin-runtime.k"
 module VERIFICATION
     imports EDSL
     imports LEMMAS
-    imports INFINITE-GAS
     imports EVM-OPTIMIZATIONS
     imports ERC20-BIN-RUNTIME
 

--- a/tests/specs/examples/erc721-spec.md
+++ b/tests/specs/examples/erc721-spec.md
@@ -5,7 +5,6 @@ ERC721-ish Verification
 requires "edsl.md"
 requires "optimizations.md"
 requires "lemmas/lemmas.k"
-requires "lemmas/infinite-gas.k"
 ```
 
 Solidity Code
@@ -28,7 +27,6 @@ requires "erc721-bin-runtime.k"
 module VERIFICATION
     imports EDSL
     imports LEMMAS
-    imports INFINITE-GAS
     imports EVM-OPTIMIZATIONS
     imports ERC721-BIN-RUNTIME
 

--- a/tests/specs/examples/solidity-code-spec.md
+++ b/tests/specs/examples/solidity-code-spec.md
@@ -5,7 +5,6 @@ Solidity Verification Example
 requires "edsl.md"
 requires "optimizations.md"
 requires "lemmas/lemmas.k"
-requires "lemmas/infinite-gas.k"
 ```
 
 Solidity Code
@@ -58,7 +57,6 @@ Helper module for verification tasks.
 module VERIFICATION
     imports EDSL
     imports LEMMAS
-    imports INFINITE-GAS
     imports EVM-OPTIMIZATIONS
 
     rule #getValue(#uint256(X)) => X requires #rangeUInt(256, X) [simplification]

--- a/tests/specs/foundry/foundry-spec.k.check.expected
+++ b/tests/specs/foundry/foundry-spec.k.check.expected
@@ -66,7 +66,7 @@ module FOUNDRY-SPEC
                    ( 0 => ?_PC_CELL_acd26fc5 )
                  </pc>
                  <gas>
-                   ( infGas ( _VGAS ) => ?_GAS_CELL_acd26fc5 )
+                   ( #gas ( _VGAS ) => ?_GAS_CELL_acd26fc5 )
                  </gas>
                  <memoryUsed>
                    ( 0 => ?_MEMORYUSED_CELL_acd26fc5 )
@@ -257,7 +257,7 @@ module FOUNDRY-SPEC
                    ( 0 => ?_PC_CELL_acd26fc5 )
                  </pc>
                  <gas>
-                   ( infGas ( _VGAS ) => ?_GAS_CELL_acd26fc5 )
+                   ( #gas ( _VGAS ) => ?_GAS_CELL_acd26fc5 )
                  </gas>
                  <memoryUsed>
                    ( 0 => ?_MEMORYUSED_CELL_acd26fc5 )

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -1,7 +1,9 @@
 requires "infinite-gas.md"
+requires "lemmas/int-simplification.k"
 
 module VERIFICATION
     imports INFINITE-GAS
+    imports INT-SIMPLIFICATION
 
     syntax KItem ::= runLemma ( Step ) | doneLemma ( Step )
  // -------------------------------------------------------

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -1,4 +1,4 @@
-requires "../infinite-gas.k"
+requires "infinite-gas.md"
 
 module VERIFICATION
     imports INFINITE-GAS

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -13,6 +13,7 @@ endmodule
 module LEMMAS-MCD
     imports LEMMAS-MCD-HASKELL
     imports LEMMAS-MCD-JAVA
+    imports INFINITE-GAS-JAVA-EXTRA
 
 endmodule
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -1,7 +1,6 @@
 requires "../lemmas.k"
 requires "bin_runtime.k"
 requires "storage.k"
-requires "../infinite-gas.k"
 requires "word-pack.k"
 
 module VERIFICATION
@@ -169,7 +168,6 @@ endmodule
 
 module LEMMAS-MCD-COMMON
     imports LEMMAS-MCD-SYNTAX
-    imports INFINITE-GAS
     imports WORD-PACK
 
   // ########################


### PR DESCRIPTION
Module `INFINITE-GAS` is used so often for any verification, that it is promoted to part of `EDSL`, so that it comes with the default Haskell backend that KEVM ships.