### PR TITLE
Fix up unparsing when generating specifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ tests/gen-spec/foundry/out:
 	cd $(dir $@) && forge build --extra-output storageLayout --extra-output abi --extra-output evm.methodIdentifiers --extra-output evm.deployedBytecode.object
 
 tests/gen-spec/foundry/bin-runtime.k.check: tests/gen-spec/foundry/out tests/specs/foundry/verification/haskell/timestamp kevm-pyk-venv
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) foundry-to-k $< --verbose --definition tests/specs/foundry/verification/haskell > $@.out
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) foundry-to-k $< --verbose --definition tests/specs/foundry/verification/haskell --main-module VERIFICATION-EXT > $@.out
 	$(CHECK) $@.out $@.expected
 
 tests/specs/foundry/foundry-spec.k.check: tests/specs/foundry/verification/haskell/timestamp kevm-pyk-venv

--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,7 @@ tests/gen-spec/foundry/out:
 	cd $(dir $@) && forge build --extra-output storageLayout --extra-output abi --extra-output evm.methodIdentifiers --extra-output evm.deployedBytecode.object
 
 tests/gen-spec/foundry/bin-runtime.k.check: tests/gen-spec/foundry/out tests/specs/foundry/verification/haskell/timestamp kevm-pyk-venv
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) foundry-to-k $< --verbose --definition tests/specs/foundry/verification/haskell --main-module VERIFICATION-EXT > $@.out
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) foundry-to-k $< --verbose --definition tests/specs/foundry/verification/haskell > $@.out
 	$(CHECK) $@.out $@.expected
 
 tests/specs/foundry/foundry-spec.k.check: tests/specs/foundry/verification/haskell/timestamp kevm-pyk-venv

--- a/edsl.md
+++ b/edsl.md
@@ -19,17 +19,18 @@ module EDSL
     imports EVM-ABI
     imports EVM-OPTIMIZATIONS
     imports INFINITE-GAS
+    imports BIN-RUNTIME
 endmodule
 
 module BIN-RUNTIME
-    imports EDSL
+    imports EVM-ABI
 
     syntax Contract
-    syntax ByteArray ::= #binRuntime ( Contract ) [alias, klabel(binRuntime), symbol, function, no-evaluators]
- // ----------------------------------------------------------------------------------------------------------
+    syntax ByteArray ::= #binRuntime ( Contract ) [alias, klabel(binRuntime), function, no-evaluators]
+ // --------------------------------------------------------------------------------------------------
 
-    syntax Int ::= selector ( String ) [alias, klabel(abi_selector), symbol, function, no-evaluators]
- // -------------------------------------------------------------------------------------------------
+    syntax Int ::= selector ( String ) [alias, klabel(abi_selector), function, no-evaluators]
+ // -----------------------------------------------------------------------------------------
 
 endmodule
 ```

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -7,10 +7,11 @@ from typing import Final, List
 
 from pyk.cli_utils import dir_path, file_path
 from pyk.kast import KDefinition, KFlatModule, KImport, KRequire
+from pyk.prelude import Sorts
 
 from .kevm import KEVM
 from .solc_to_k import contract_to_k, gen_spec_modules, solc_compile
-from .utils import add_include_arg
+from .utils import KDefinition_empty_config, add_include_arg
 
 _LOGGER: Final = logging.getLogger(__name__)
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
@@ -71,10 +72,12 @@ def main():
             kevm.symbol_table['binRuntime']     = lambda s: '#binRuntime(' + s + ')'                                                        # noqa
             kevm.symbol_table['abi_selector']   = lambda s: 'selector(' + s + ')'                                                           # noqa
 
+            empty_config = KDefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
+
             if args.command == 'solc-to-k':
                 solc_json = solc_compile(args.contract_file)
                 contract_json = solc_json['contracts'][args.contract_file.name][args.contract_name]
-                contract_module = contract_to_k(contract_json, args.contract_name, args.generate_storage)
+                contract_module = contract_to_k(contract_json, args.contract_name, args.generate_storage, empty_config)
                 bin_runtime_definition = KDefinition(contract_module.name, [contract_module], requires=[KRequire('edsl.md')])
                 kevm.symbol_table[args.contract_name] = lambda: args.contract_name
                 print(kevm.pretty_print(bin_runtime_definition) + '\n')
@@ -89,7 +92,7 @@ def main():
                     contract_name = contract_name[0:-5] if contract_name.endswith('.json') else contract_name
                     with open(json_file, 'r') as cjson:
                         contract_json = json.loads(cjson.read())
-                        module = contract_to_k(contract_json, contract_name, args.generate_storage, foundry=True)
+                        module = contract_to_k(contract_json, contract_name, args.generate_storage, empty_config, foundry=True)
                         kevm.symbol_table[contract_name] = lambda: contract_name
                         _LOGGER.info(f'Produced contract module: {module.name}')
                         modules.append(module)

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -181,3 +181,7 @@ class KEVM(KProve):
     @staticmethod
     def wordstack_len(constrainedTerm: KInner) -> int:
         return len(flattenLabel('_:__EVM-TYPES_WordStack_Int_WordStack', getCell(constrainedTerm, 'WORDSTACK_CELL')))
+
+    @staticmethod
+    def parse_bytestack(s: KInner):
+        return KApply('#parseByteStack(_)_SERIALIZATION_ByteArray_String', [s])

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -149,9 +149,9 @@ class KEVM(KProve):
         return KApply('#binRuntime', [c])
 
     @staticmethod
-    def abi_calldata(n: str, args: List[KInner]):
-        token: KInner = stringToken(n)
-        return KApply('#abiCallData', [token] + args)
+    def abi_calldata(name: str, args: List[KInner]):
+        token: KInner = stringToken(name)
+        return KApply('#abiCallData(_,_)_EVM-ABI_ByteArray_String_TypedArgs', [token] + args)
 
     @staticmethod
     def abi_address(a: KInner) -> KApply:

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -154,6 +154,10 @@ class KEVM(KProve):
         return KApply('#abiCallData(_,_)_EVM-ABI_ByteArray_String_TypedArgs', [token] + args)
 
     @staticmethod
+    def abi_selector(name: str):
+        return KApply('abi_selector', [stringToken(name)])
+
+    @staticmethod
     def abi_address(a: KInner) -> KApply:
         return KApply('#address(_)_EVM-ABI_TypedArg_Int', [a])
 

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -6,12 +6,12 @@ from subprocess import CalledProcessError
 from typing import Any, Dict, Final, List, Optional
 
 from pyk.cli_utils import run_process
-from pyk.kast import KApply, KInner, KSort
+from pyk.kast import KApply, KInner
 from pyk.kastManip import flattenLabel, getCell
 from pyk.ktool import KProve, paren
 from pyk.prelude import intToken, stringToken
 
-from .utils import add_include_arg, build_empty_config_cell
+from .utils import add_include_arg
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -24,9 +24,6 @@ class KEVM(KProve):
     def __init__(self, kompiled_directory, main_file_name=None, use_directory=None):
         super().__init__(kompiled_directory, main_file_name=main_file_name, use_directory=use_directory)
         KEVM._patch_symbol_table(self.symbol_table)
-
-    def empty_config(self, top_cell: KSort = KSort('GeneratedTopCell')) -> KInner:
-        return build_empty_config_cell(self.definition, top_cell)
 
     @staticmethod
     def kompile(

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -132,7 +132,7 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
 
     contract_subsort = KProduction(KSort('Contract'), [KNonTerminal(contract_sort)])
     contract_production = KProduction(contract_sort, [KTerminal(contract_name)], att=KAtt({'klabel': f'contract_{contract_name}', 'symbol': ''}))
-    contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_name)]), _parseByteStack(stringToken(bin_runtime))))
+    contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_name)]), KEVM.parse_bytestack(stringToken(bin_runtime))))
 
     module_name = contract_name.upper() + '-BIN-RUNTIME'
     module = KFlatModule(
@@ -322,10 +322,6 @@ def _extract_function_sentences(contract_name, function_sort, abi) -> List[Tuple
         inputs = func_dict['inputs']
         res.append((extract_production(name, inputs), extract_rule(name, inputs)))
     return res
-
-
-def _parseByteStack(s: KInner):
-    return KApply('#parseByteStack(_)_SERIALIZATION_ByteArray_String', [s])
 
 
 def _check_supported_value_type(type_label: str) -> None:

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -26,7 +26,7 @@ from pyk.kast import (
     KToken,
     KVariable,
 )
-from pyk.kastManip import buildRule, remove_generated_cells, substitute
+from pyk.kastManip import buildRule, substitute
 from pyk.prelude import Sorts, intToken, stringToken
 from pyk.utils import intersperse
 
@@ -74,7 +74,7 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
 
 
 def gen_claims_for_contract(defn: KDefinition, contract_name: str) -> List[KClaim]:
-    empty_config = remove_generated_cells(kdefinition_empty_config(defn, Sorts.GENERATED_TOP_CELL))
+    empty_config = kdefinition_empty_config(defn, Sorts.GENERATED_TOP_CELL)
     program = KApply('binRuntime', [KApply('contract_' + contract_name)])
     account_cell = KEVM.account_cell(KVariable('ACCT_ID'), KVariable('ACCT_BALANCE'), program, KVariable('ACCT_STORAGE'), KVariable('ACCT_ORIGSTORAGE'), KVariable('ACCT_NONCE'))
     init_subst = {

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -138,7 +138,7 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
     module = KFlatModule(
         module_name,
         [contract_subsort, contract_production] + storage_sentences + function_sentences + [contract_macro] + function_selector_alias_sentences,
-        [KImport('BIN-RUNTIME', True)],
+        [KImport('EDSL', True)],
     )
 
     return module

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -27,11 +27,11 @@ from pyk.kast import (
     KVariable,
 )
 from pyk.kastManip import buildRule, remove_generated_cells, substitute
-from pyk.prelude import intToken, stringToken
+from pyk.prelude import Sorts, intToken, stringToken
 from pyk.utils import intersperse
 
 from .kevm import KEVM
-from .utils import abstract_cell_vars
+from .utils import abstract_cell_vars, kdefinition_empty_config
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -73,8 +73,8 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
     return json.loads(process_res.stdout)
 
 
-def gen_claims_for_contract(kevm: KEVM, contract_name: str) -> List[KClaim]:
-    empty_config = remove_generated_cells(kevm.empty_config())
+def gen_claims_for_contract(defn: KDefinition, contract_name: str) -> List[KClaim]:
+    empty_config = remove_generated_cells(kdefinition_empty_config(defn, Sorts.GENERATED_TOP_CELL))
     program = KApply('binRuntime', [KApply('contract_' + contract_name)])
     account_cell = KEVM.account_cell(KVariable('ACCT_ID'), KVariable('ACCT_BALANCE'), program, KVariable('ACCT_STORAGE'), KVariable('ACCT_ORIGSTORAGE'), KVariable('ACCT_NONCE'))
     init_subst = {
@@ -106,7 +106,7 @@ def gen_claims_for_contract(kevm: KEVM, contract_name: str) -> List[KClaim]:
 def gen_spec_modules(kevm: KEVM, spec_module_name: str) -> str:
     production_labels = [prod.klabel for module in kevm.definition for prod in module.productions if prod.klabel is not None]
     contract_names = [prod_label.name[9:] for prod_label in production_labels if prod_label.name.startswith('contract_')]
-    claims = [claim for name in contract_names for claim in gen_claims_for_contract(kevm, name)]
+    claims = [claim for name in contract_names for claim in gen_claims_for_contract(kevm.definition, name)]
     spec_module = KFlatModule(spec_module_name, claims, [KImport(kevm.definition.main_module_name)])
     spec_defn = KDefinition(spec_module_name, [spec_module], [KRequire('verification.k')])
     return kevm.pretty_print(spec_defn)

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -15,6 +15,7 @@ from pyk.kast import (
     KFlatModule,
     KImport,
     KInner,
+    KLabel,
     KNonTerminal,
     KProduction,
     KRequire,
@@ -231,7 +232,7 @@ def _extract_storage_sentences(contract_name, storage_sort, storage_layout):
 
 def generate_function_sentences(contract_name, contract_sort, abi):
     function_sort = KSort(f'{contract_name}Function')
-    function_call_data_production = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], att=KAtt({'klabel': f'function_{contract_name}', 'symbol': '', 'function': ''}))
+    function_call_data_production = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], att=KAtt({'symbol': '', 'function': ''}), klabel=KLabel(f'function_{contract_name}'))
     function_sentence_pairs = _extract_function_sentences(contract_name, function_sort, abi)
 
     if not function_sentence_pairs:
@@ -263,7 +264,7 @@ def _extract_function_sentences(contract_name, function_sort, abi):
         items += intersperse(input_nonterminals, KTerminal(','))
 
         items.append(KTerminal(')'))
-        return KProduction(function_sort, items)
+        return KProduction(function_sort, items, klabel=KLabel(f'{contract_name}_function_{name}'))
 
     def extract_rule(name, inputs):
         input_names = normalize_input_names([input_dict['name'] for input_dict in inputs])

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -126,8 +126,7 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
     if generate_storage:
         storage_layout = contract_json['storageLayout']
         storage_sentences = generate_storage_sentences(contract_name, contract_sort, storage_layout)
-    function_call_data_production, function_productions, function_rules = generate_function_sentences(contract_name, contract_sort, abi)
-    function_sentences = [function_call_data_production] + function_productions + function_rules
+    function_sentences = generate_function_sentences(contract_name, contract_sort, abi)
     function_selector_alias_sentences = generate_function_selector_alias_sentences(contract_name, contract_sort, hashes)
 
     contract_klabel = KLabel(f'contract_{contract_name}')

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -130,9 +130,10 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
     function_sentences = [function_call_data_production] + function_productions + function_rules
     function_selector_alias_sentences = generate_function_selector_alias_sentences(contract_name, contract_sort, hashes)
 
+    contract_klabel = KLabel(f'contract_{contract_name}')
     contract_subsort = KProduction(KSort('Contract'), [KNonTerminal(contract_sort)])
-    contract_production = KProduction(contract_sort, [KTerminal(contract_name)], att=KAtt({'klabel': f'contract_{contract_name}', 'symbol': ''}))
-    contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_name)]), KEVM.parse_bytestack(stringToken(bin_runtime))))
+    contract_production = KProduction(contract_sort, [KTerminal(contract_name)], klabel=contract_klabel)
+    contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_klabel)]), KEVM.parse_bytestack(stringToken(bin_runtime))))
 
     module_name = contract_name.upper() + '-BIN-RUNTIME'
     module = KFlatModule(

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -252,7 +252,7 @@ def generate_function_selector_alias_sentences(contract_name, contract_sort, has
     for h in hashes:
         f_name = h.split('(')[0]
         hash_int = int(hashes[h], 16)
-        abi_function_selector_rewrite = KRewrite(KApply('abi_selector', [stringToken(f'{f_name}')]), intToken(hash_int))
+        abi_function_selector_rewrite = KRewrite(KEVM.abi_selector(f_name), intToken(hash_int))
         abi_function_selector_rules.append(KRule(abi_function_selector_rewrite))
     return abi_function_selector_rules
 

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -136,11 +136,8 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
     contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_klabel)]), KEVM.parse_bytestack(stringToken(bin_runtime))))
 
     module_name = contract_name.upper() + '-BIN-RUNTIME'
-    module = KFlatModule(
-        module_name,
-        [contract_subsort, contract_production] + storage_sentences + function_sentences + [contract_macro] + function_selector_alias_sentences,
-        [KImport('EDSL', True)],
-    )
+    sentences = [contract_subsort, contract_production] + storage_sentences + function_sentences + [contract_macro] + function_selector_alias_sentences
+    module = KFlatModule(module_name, sentences, [KImport('EDSL')])
 
     return module
 

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -234,7 +234,7 @@ def _extract_storage_sentences(contract_name, storage_sort, storage_layout):
 
 def generate_function_sentences(contract_name: str, contract_sort: KSort, abi):
     function_sort = KSort(f'{contract_name}Function')
-    function_call_data_production: KSentence = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], att=KAtt({'symbol': '', 'function': ''}), klabel=KLabel(f'function_{contract_name}'))
+    function_call_data_production: KSentence = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], klabel=KLabel(f'function_{contract_name}'), att=KAtt({'function': ''}))
     function_sentence_pairs = _extract_function_sentences(contract_name, function_sort, abi)
 
     function_productions: List[KSentence] = []

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -281,7 +281,7 @@ def _extract_function_sentences(contract_name, function_sort, abi):
 
     def extract_rhs(name, input_names, input_types):
         args = [KApply('abi_type_' + input_type, [KVariable(input_name)]) for input_name, input_type in zip(input_names, input_types)] or [KToken('.TypedArgs', 'TypedArgs')]
-        return KApply('abiCallData', [stringToken(name)] + args)
+        return KEVM.abi_calldata(name, args)
 
     def extract_ensures(input_names, input_types):
         opt_conjuncts = [_range_predicate(KVariable(input_name), input_type) for input_name, input_type in zip(input_names, input_types)]

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -44,7 +44,7 @@ def get_label_for_cell_sorts(definition, sort):
     return productions[0].klabel
 
 
-def build_empty_config_cell(definition, sort):
+def kdefinition_empty_config(definition, sort):
     label = get_label_for_cell_sorts(definition, sort)
     production = get_production_for_klabel(definition, label)
     args = []
@@ -54,7 +54,7 @@ def build_empty_config_cell(definition, sort):
         if type(p_item) is KNonTerminal:
             num_nonterminals += 1
             if p_item.sort.name.endswith('Cell'):
-                args.append(build_empty_config_cell(definition, p_item.sort))
+                args.append(kdefinition_empty_config(definition, p_item.sort))
             else:
                 num_freshvars += 1
                 args.append(KVariable(sort.name[0:-4].upper() + '_CELL'))

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -1,6 +1,10 @@
+from typing import List
+
 from pyk.kast import (
     KApply,
     KDefinition,
+    KFlatModule,
+    KImport,
     KInner,
     KNonTerminal,
     KSort,
@@ -15,6 +19,24 @@ from pyk.kastManip import (
     splitConfigFrom,
     substitute,
 )
+from pyk.ktool import KPrint
+from pyk.ktool.kprint import build_symbol_table
+from pyk.utils import hash_str
+
+
+def KPrint_make_unparsing(_self: KPrint, extra_modules: List[KFlatModule] = []) -> KPrint:
+    modules = list(_self.definition.modules) + extra_modules
+    main_module = KFlatModule('UNPARSING', [], [KImport(_m.name) for _m in modules])
+    defn = KDefinition('UNPARSING', [main_module] + modules)
+    kprint = KPrint(_self.kompiled_directory)
+    kprint.definition = defn
+    kprint.symbol_table = build_symbol_table(kprint.definition, opinionated=True)
+    kprint.definition_hash = hash_str(kprint.definition)
+    return kprint
+
+
+def KDefinition_module_names(_self: KDefinition) -> List[str]:
+    return [_m.name for _m in _self.modules]
 
 
 def KDefinition_empty_config(definition: KDefinition, sort: KSort) -> KInner:

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -17,6 +17,30 @@ from pyk.kastManip import (
 )
 
 
+def KDefinition_empty_config(definition: KDefinition, sort: KSort) -> KInner:
+
+    def _kdefinition_empty_config(_sort):
+        label = get_label_for_cell_sorts(definition, _sort)
+        production = get_production_for_klabel(definition, label)
+        args = []
+        num_nonterminals = 0
+        num_freshvars = 0
+        for p_item in production.items:
+            if type(p_item) is KNonTerminal:
+                num_nonterminals += 1
+                if p_item.sort.name.endswith('Cell'):
+                    args.append(_kdefinition_empty_config(p_item.sort))
+                else:
+                    num_freshvars += 1
+                    args.append(KVariable(_sort.name[0:-4].upper() + '_CELL'))
+        if num_nonterminals > 1 and num_freshvars > 0:
+            sort_name = sort.name
+            raise ValueError(f'Found mixed cell and non-cell arguments to cell constructor for {sort_name}!')
+        return KApply(label, args)
+
+    return remove_generated_cells(_kdefinition_empty_config(sort))
+
+
 def add_include_arg(includes):
     return [arg for include in includes for arg in ['-I', include]]
 
@@ -51,27 +75,3 @@ def get_label_for_cell_sorts(definition, sort):
     if len(productions) != 1:
         raise ValueError(f'Expected 1 production for sort {sort}, not {productions}!')
     return productions[0].klabel
-
-
-def kdefinition_empty_config(definition: KDefinition, sort: KSort) -> KInner:
-
-    def _kdefinition_empty_config(_sort):
-        label = get_label_for_cell_sorts(definition, _sort)
-        production = get_production_for_klabel(definition, label)
-        args = []
-        num_nonterminals = 0
-        num_freshvars = 0
-        for p_item in production.items:
-            if type(p_item) is KNonTerminal:
-                num_nonterminals += 1
-                if p_item.sort.name.endswith('Cell'):
-                    args.append(_kdefinition_empty_config(p_item.sort))
-                else:
-                    num_freshvars += 1
-                    args.append(KVariable(_sort.name[0:-4].upper() + '_CELL'))
-        if num_nonterminals > 1 and num_freshvars > 0:
-            sort_name = sort.name
-            raise ValueError(f'Found mixed cell and non-cell arguments to cell constructor for {sort_name}!')
-        return KApply(label, args)
-
-    return remove_generated_cells(_kdefinition_empty_config(sort))

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -1,7 +1,16 @@
-from pyk.kast import KApply, KNonTerminal, KTerminal, KVariable
+from pyk.kast import (
+    KApply,
+    KDefinition,
+    KInner,
+    KNonTerminal,
+    KSort,
+    KTerminal,
+    KVariable,
+)
 from pyk.kastManip import (
     abstract_term_safely,
     isAnonVariable,
+    remove_generated_cells,
     splitConfigAndConstraints,
     splitConfigFrom,
     substitute,
@@ -44,21 +53,25 @@ def get_label_for_cell_sorts(definition, sort):
     return productions[0].klabel
 
 
-def kdefinition_empty_config(definition, sort):
-    label = get_label_for_cell_sorts(definition, sort)
-    production = get_production_for_klabel(definition, label)
-    args = []
-    num_nonterminals = 0
-    num_freshvars = 0
-    for p_item in production.items:
-        if type(p_item) is KNonTerminal:
-            num_nonterminals += 1
-            if p_item.sort.name.endswith('Cell'):
-                args.append(kdefinition_empty_config(definition, p_item.sort))
-            else:
-                num_freshvars += 1
-                args.append(KVariable(sort.name[0:-4].upper() + '_CELL'))
-    if num_nonterminals > 1 and num_freshvars > 0:
-        sort_name = sort.name
-        raise ValueError(f'Found mixed cell and non-cell arguments to cell constructor for {sort_name}!')
-    return KApply(label, args)
+def kdefinition_empty_config(definition: KDefinition, sort: KSort) -> KInner:
+
+    def _kdefinition_empty_config(_sort):
+        label = get_label_for_cell_sorts(definition, _sort)
+        production = get_production_for_klabel(definition, label)
+        args = []
+        num_nonterminals = 0
+        num_freshvars = 0
+        for p_item in production.items:
+            if type(p_item) is KNonTerminal:
+                num_nonterminals += 1
+                if p_item.sort.name.endswith('Cell'):
+                    args.append(_kdefinition_empty_config(p_item.sort))
+                else:
+                    num_freshvars += 1
+                    args.append(KVariable(_sort.name[0:-4].upper() + '_CELL'))
+        if num_nonterminals > 1 and num_freshvars > 0:
+            sort_name = sort.name
+            raise ValueError(f'Found mixed cell and non-cell arguments to cell constructor for {sort_name}!')
+        return KApply(label, args)
+
+    return remove_generated_cells(_kdefinition_empty_config(sort))

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -28,7 +28,7 @@ def KPrint_make_unparsing(_self: KPrint, extra_modules: List[KFlatModule] = []) 
     modules = list(_self.definition.modules) + extra_modules
     main_module = KFlatModule('UNPARSING', [], [KImport(_m.name) for _m in modules])
     defn = KDefinition('UNPARSING', [main_module] + modules)
-    kprint = KPrint(_self.kompiled_directory)
+    kprint = KPrint(str(_self.kompiled_directory))
     kprint.definition = defn
     kprint.symbol_table = build_symbol_table(kprint.definition, opinionated=True)
     kprint.definition_hash = hash_str(kprint.definition)

--- a/tests/gen-spec/dai-bin-runtime.k
+++ b/tests/gen-spec/dai-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module DAI-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= DaiContract 
     

--- a/tests/gen-spec/daijoin-bin-runtime.k
+++ b/tests/gen-spec/daijoin-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module DAIJOIN-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= DaiJoinContract 
     

--- a/tests/gen-spec/foundry/bin-runtime.k.check.expected
+++ b/tests/gen-spec/foundry/bin-runtime.k.check.expected
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module CONTRACT-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= ContractContract 
     
@@ -13,7 +13,7 @@ module CONTRACT-BIN-RUNTIME
 endmodule
 
 module CONTRACTTEST-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= ContractTestContract 
     

--- a/tests/gen-spec/foundry/bin-runtime.k.check.expected
+++ b/tests/gen-spec/foundry/bin-runtime.k.check.expected
@@ -7,7 +7,7 @@ module CONTRACT-BIN-RUNTIME
     
     syntax ContractContract ::= "Contract" [klabel(contract_Contract), symbol()]
     
-    rule  ( #binRuntime(ContractTest) => #parseByteStack ( "0x0x6080604052600080fdfea2646970667358221220febf745518acc26f684d27983160459fa2f213f0d4664cb72e4e8885a5fc079664736f6c634300080f0033" ) )
+    rule  ( #binRuntime ( Contract ) => #parseByteStack ( "0x0x6080604052600080fdfea2646970667358221220febf745518acc26f684d27983160459fa2f213f0d4664cb72e4e8885a5fc079664736f6c634300080f0033" ) )
       
 
 endmodule
@@ -19,33 +19,33 @@ module CONTRACTTEST-BIN-RUNTIME
     
     syntax ContractTestContract ::= "ContractTest" [klabel(contract_ContractTest), symbol()]
     
-    syntax ByteArray ::= ContractTestContract "." ContractTestFunction [klabel(function_ContractTest), symbol(), function()]
+    syntax ByteArray ::= ContractTestContract "." ContractTestFunction [function(), klabel(function_ContractTest)]
     
-    syntax ContractTestFunction ::= "setUp" "(" ")" 
+    syntax ContractTestFunction ::= "setUp" "(" ")" [klabel(ContractTest_function_setUp)]
     
-    syntax ContractTestFunction ::= "test_1" "(" ")" 
+    syntax ContractTestFunction ::= "test_1" "(" ")" [klabel(ContractTest_function_test_1)]
     
-    syntax ContractTestFunction ::= "test_2" "(" ")" 
+    syntax ContractTestFunction ::= "test_2" "(" ")" [klabel(ContractTest_function_test_2)]
     
-    rule  ( ContractTest.setUp() => #abiCallData("setUp", .TypedArgs) )
+    rule  ( ContractTest.setUp() => #abiCallData ( "setUp" , .TypedArgs ) )
       
     
-    rule  ( ContractTest.test_1() => #abiCallData("test_1", .TypedArgs) )
+    rule  ( ContractTest.test_1() => #abiCallData ( "test_1" , .TypedArgs ) )
       
     
-    rule  ( ContractTest.test_2() => #abiCallData("test_2", .TypedArgs) )
+    rule  ( ContractTest.test_2() => #abiCallData ( "test_2" , .TypedArgs ) )
       
     
-    rule  ( #binRuntime(ContractTest) => #parseByteStack ( "0x0x6080604052348015600f57600080fd5b5060043610603c5760003560e01c80630a9254e4146041578063663bc990146041578063899eb49c146043575b600080fd5b005b6041604b565b565b6049634e487b7160e01b600052600160045260246000fdfea264697066735822122088b9c698d4d8963d9636778228b7adb6c08b645395e41f0e34b84090ec109da464736f6c634300080f0033" ) )
+    rule  ( #binRuntime ( ContractTest ) => #parseByteStack ( "0x0x6080604052348015600f57600080fd5b5060043610603c5760003560e01c80630a9254e4146041578063663bc990146041578063899eb49c146043575b600080fd5b005b6041604b565b565b6049634e487b7160e01b600052600160045260246000fdfea264697066735822122088b9c698d4d8963d9636778228b7adb6c08b645395e41f0e34b84090ec109da464736f6c634300080f0033" ) )
       
     
-    rule  ( selector("setUp") => 177362148 )
+    rule  ( selector ( "setUp" ) => 177362148 )
       
     
-    rule  ( selector("test_1") => 1715194256 )
+    rule  ( selector ( "test_1" ) => 1715194256 )
       
     
-    rule  ( selector("test_2") => 2308879516 )
+    rule  ( selector ( "test_2" ) => 2308879516 )
       
 
 endmodule

--- a/tests/gen-spec/foundry/bin-runtime.k.check.expected
+++ b/tests/gen-spec/foundry/bin-runtime.k.check.expected
@@ -5,7 +5,7 @@ module CONTRACT-BIN-RUNTIME
     
     syntax Contract ::= ContractContract 
     
-    syntax ContractContract ::= "Contract" [klabel(contract_Contract), symbol()]
+    syntax ContractContract ::= "Contract" [klabel(contract_Contract)]
     
     rule  ( #binRuntime ( Contract ) => #parseByteStack ( "0x0x6080604052600080fdfea2646970667358221220febf745518acc26f684d27983160459fa2f213f0d4664cb72e4e8885a5fc079664736f6c634300080f0033" ) )
       
@@ -17,7 +17,7 @@ module CONTRACTTEST-BIN-RUNTIME
     
     syntax Contract ::= ContractTestContract 
     
-    syntax ContractTestContract ::= "ContractTest" [klabel(contract_ContractTest), symbol()]
+    syntax ContractTestContract ::= "ContractTest" [klabel(contract_ContractTest)]
     
     syntax ByteArray ::= ContractTestContract "." ContractTestFunction [function(), klabel(function_ContractTest)]
     

--- a/tests/gen-spec/gemjoin-bin-runtime.k
+++ b/tests/gen-spec/gemjoin-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module GEMJOIN-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= GemJoinContract 
     

--- a/tests/gen-spec/jug-bin-runtime.k
+++ b/tests/gen-spec/jug-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module JUG-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= JugContract 
     

--- a/tests/gen-spec/mcd-spec.k.check.expected
+++ b/tests/gen-spec/mcd-spec.k.check.expected
@@ -39,10 +39,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Vat) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Vat ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Vat) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Vat ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -174,7 +174,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Vat)
+                     #binRuntime ( Vat )
                    </code>
                    ...
                  </account>
@@ -230,10 +230,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Jug) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Jug ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Jug) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Jug ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -365,7 +365,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Jug)
+                     #binRuntime ( Jug )
                    </code>
                    ...
                  </account>
@@ -421,10 +421,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(DaiJoin) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( DaiJoin ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(DaiJoin) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( DaiJoin ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -556,7 +556,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(DaiJoin)
+                     #binRuntime ( DaiJoin )
                    </code>
                    ...
                  </account>
@@ -612,10 +612,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Dai) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Dai ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Dai) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Dai ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -747,7 +747,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Dai)
+                     #binRuntime ( Dai )
                    </code>
                    ...
                  </account>
@@ -803,10 +803,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(GemJoin) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( GemJoin ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(GemJoin) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( GemJoin ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -938,7 +938,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(GemJoin)
+                     #binRuntime ( GemJoin )
                    </code>
                    ...
                  </account>
@@ -994,10 +994,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Pot) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Pot ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Pot) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Pot ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -1129,7 +1129,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Pot)
+                     #binRuntime ( Pot )
                    </code>
                    ...
                  </account>
@@ -1185,10 +1185,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Spotter) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Spotter ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Spotter) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Spotter ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -1320,7 +1320,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Spotter)
+                     #binRuntime ( Spotter )
                    </code>
                    ...
                  </account>

--- a/tests/gen-spec/pot-bin-runtime.k
+++ b/tests/gen-spec/pot-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module POT-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= PotContract 
     

--- a/tests/gen-spec/spotter-bin-runtime.k
+++ b/tests/gen-spec/spotter-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module SPOTTER-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= SpotterContract 
     

--- a/tests/gen-spec/vat-bin-runtime.k
+++ b/tests/gen-spec/vat-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module VAT-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= VatContract 
     

--- a/tests/gen-spec/verification.k
+++ b/tests/gen-spec/verification.k
@@ -10,7 +10,6 @@ requires "vat-bin-runtime.k"
 
 module MCD-VERIFICATION
     imports LEMMAS
-    imports INFINITE-GAS
 
     imports DAI-BIN-RUNTIME
     imports DAIJOIN-BIN-RUNTIME

--- a/tests/specs/foundry/bin-runtime.k
+++ b/tests/specs/foundry/bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module CONTRACT-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports EDSL
     
     syntax Contract ::= ContractContract 
     
@@ -13,7 +13,7 @@ module CONTRACT-BIN-RUNTIME
 endmodule
 
 module CONTRACTTEST-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports EDSL
     
     syntax Contract ::= ContractTestContract 
     

--- a/tests/specs/foundry/foundry-spec.k.check.expected
+++ b/tests/specs/foundry/foundry-spec.k.check.expected
@@ -39,10 +39,10 @@ module FOUNDRY-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(ContractTest) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( ContractTest ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(ContractTest) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( ContractTest ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -174,7 +174,7 @@ module FOUNDRY-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(ContractTest)
+                     #binRuntime ( ContractTest )
                    </code>
                    ...
                  </account>
@@ -230,10 +230,10 @@ module FOUNDRY-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Contract) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Contract ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Contract) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Contract ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -365,7 +365,7 @@ module FOUNDRY-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Contract)
+                     #binRuntime ( Contract )
                    </code>
                    ...
                  </account>


### PR DESCRIPTION
This PR enables re-building the unparser after adding the productions with the K helpers defined for a contract.
That way, we are not manually patching the symbol table to unparse these generated productions.

- `contract_to_k` and `gen_claims_for_contract` are lowered to take an `empty_config` as input, instead of a entire `KEVM`, which makes it easier to use them in more places (for a later PR).
- The typing around some of the generator functions is tightened up, to help catch errors earlier: `_extract_function_sentences`, `generate_function_sentences`.
- `_parseByteStack` is moved to a static method `KEVM.parse_bytestack`.
- Factors out functions which should be upstreamed in `utils.py`: `KPrint_make_unparsing` and `KDefinition_module_names` and `KDefinition_empty_config`.
- Adds `klabel`s to some of the generated functions in the specification, for proper unparsing.
- Removes the symbol table updates that were used for unparsing, in favor of rebuilding an unparser after adding the generated productions.