### PR TITLE
Adjustments to kevm_pyk spec generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,22 +437,22 @@ tests/gen-spec/foundry/bin-runtime.k.check: tests/gen-spec/foundry/out tests/spe
 	$(CHECK) $@.out $@.expected
 
 tests/specs/foundry/foundry-spec.k.check: tests/specs/foundry/verification/haskell/timestamp kevm-pyk-venv
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) gen-spec FOUNDRY-SPEC --definition tests/specs/foundry/verification/haskell > $@.out
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) gen-spec FOUNDRY-SPEC --verbose --definition tests/specs/foundry/verification/haskell > $@.out
 	$(CHECK) $@.out $@.expected
 
 tests/specs/examples/erc20-spec/haskell/timestamp: tests/specs/examples/erc20-bin-runtime.k
 tests/specs/examples/erc20-bin-runtime.k: tests/specs/examples/ERC20.sol $(KEVM_LIB)/$(haskell_kompiled) kevm-pyk-venv
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< ERC20 --definition $(KEVM_LIB)/$(haskell_kompiled_dir) > $@
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< ERC20 --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) > $@
 
 tests/specs/examples/erc721-spec/haskell/timestamp: tests/specs/examples/erc721-bin-runtime.k
 tests/specs/examples/erc721-bin-runtime.k: tests/specs/examples/ERC721.sol $(KEVM_LIB)/$(haskell_kompiled) kevm-pyk-venv
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< ERC721 --definition $(KEVM_LIB)/$(haskell_kompiled_dir) > $@
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< ERC721 --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) > $@
 
 tests/specs/examples/empty-bin-runtime.k: tests/specs/examples/Empty.sol $(KEVM_LIB)/$(haskell_kompiled) kevm-pyk-venv
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< Empty --definition $(KEVM_LIB)/$(haskell_kompiled_dir) > $@
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) solc-to-k $< Empty --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) > $@
 
 tests/gen-spec/mcd-spec.k.check: tests/gen-spec/kompiled/timestamp kevm-pyk-venv
-	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) gen-spec MCD-SPEC --definition tests/gen-spec/kompiled > $@.out
+	. ./kevm_pyk/venv-prod/bin/activate && $(KEVM) gen-spec MCD-SPEC --verbose --definition tests/gen-spec/kompiled > $@.out
 	$(CHECK) $@.out $@.expected
 
 tests/gen-spec/kompiled/timestamp: tests/gen-spec/verification.k $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -7,11 +7,10 @@ from typing import Any, Dict, Final, List
 
 from pyk.cli_utils import dir_path, file_path
 from pyk.kast import KDefinition, KFlatModule, KImport, KRequire
-from pyk.prelude import Sorts
 
 from .kevm import KEVM
 from .solc_to_k import contract_to_k, gen_spec_modules, solc_compile
-from .utils import KDefinition_empty_config, add_include_arg
+from .utils import add_include_arg
 
 _LOGGER: Final = logging.getLogger(__name__)
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
@@ -76,12 +75,10 @@ def main():
         else:
             kevm = KEVM(args.definition_dir)
 
-            empty_config = KDefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
-
             if args.command == 'solc-to-k':
                 solc_json = solc_compile(args.contract_file)
                 contract_json = solc_json['contracts'][args.contract_file.name][args.contract_name]
-                contract_module = contract_to_k(contract_json, args.contract_name, args.generate_storage, empty_config)
+                contract_module = contract_to_k(contract_json, args.contract_name, args.generate_storage)
                 bin_runtime_definition = KDefinition(contract_module.name, [contract_module], requires=[KRequire('edsl.md')])
                 _make_unparsing(kevm.symbol_table, [args.contract_name])
                 print(kevm.pretty_print(bin_runtime_definition) + '\n')
@@ -98,7 +95,7 @@ def main():
                     contract_names.append(contract_name)
                     with open(json_file, 'r') as cjson:
                         contract_json = json.loads(cjson.read())
-                        module = contract_to_k(contract_json, contract_name, args.generate_storage, empty_config, foundry=True)
+                        module = contract_to_k(contract_json, contract_name, args.generate_storage, foundry=True)
                         _LOGGER.info(f'Produced contract module: {module.name}')
                         modules.append(module)
                 main_module = KFlatModule(args.main_module, [], [KImport(module.name) for module in modules])

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -79,7 +79,8 @@ def main():
                 contract_json = solc_json['contracts'][args.contract_file.name][args.contract_name]
                 contract_module = contract_to_k(contract_json, args.contract_name, args.generate_storage, empty_config)
                 bin_runtime_definition = KDefinition(contract_module.name, [contract_module], requires=[KRequire('edsl.md')])
-                kevm.symbol_table[args.contract_name] = lambda: args.contract_name
+                clabel = f'contract_{args.contract_name}'
+                kevm.symbol_table[clabel] = lambda: args.contract_name
                 print(kevm.pretty_print(bin_runtime_definition) + '\n')
 
             elif args.command == 'foundry-to-k':
@@ -93,7 +94,8 @@ def main():
                     with open(json_file, 'r') as cjson:
                         contract_json = json.loads(cjson.read())
                         module = contract_to_k(contract_json, contract_name, args.generate_storage, empty_config, foundry=True)
-                        kevm.symbol_table[contract_name] = lambda: contract_name
+                        clabel = f'contract_{contract_name}'
+                        kevm.symbol_table[clabel] = lambda: contract_name
                         _LOGGER.info(f'Produced contract module: {module.name}')
                         modules.append(module)
                 main_module = KFlatModule(args.main_module, [], [KImport(module.name) for module in modules])

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -55,22 +55,23 @@ def main():
         else:
             kevm = KEVM(args.definition_dir)
 
-            kevm.symbol_table['hashedLocation'] = lambda lang, base, offset: '#hashedLocation(' + lang + ', ' + base + ', ' + offset + ')'  # noqa
-            kevm.symbol_table['abiCallData']    = lambda fname, *args: '#abiCallData(' + fname + "".join(", " + arg for arg in args) + ')'  # noqa
-            kevm.symbol_table['address']        = _typed_arg_unparser('address')                                                            # noqa
-            kevm.symbol_table['bool']           = _typed_arg_unparser('bool')                                                               # noqa
-            kevm.symbol_table['bytes']          = _typed_arg_unparser('bytes')                                                              # noqa
-            kevm.symbol_table['bytes4']         = _typed_arg_unparser('bytes4')                                                             # noqa
-            kevm.symbol_table['bytes32']        = _typed_arg_unparser('bytes32')                                                            # noqa
-            kevm.symbol_table['int256']         = _typed_arg_unparser('int256')                                                             # noqa
-            kevm.symbol_table['uint256']        = _typed_arg_unparser('uint256')                                                            # noqa
-            kevm.symbol_table['rangeAddress']   = lambda t: '#rangeAddress(' + t + ')'                                                      # noqa
-            kevm.symbol_table['rangeBool']      = lambda t: '#rangeBool(' + t + ')'                                                         # noqa
-            kevm.symbol_table['rangeBytes']     = lambda n, t: '#rangeBytes(' + n + ', ' + t + ')'                                          # noqa
-            kevm.symbol_table['rangeUInt']      = lambda n, t: '#rangeUInt(' + n + ', ' + t + ')'                                           # noqa
-            kevm.symbol_table['rangeSInt']      = lambda n, t: '#rangeSInt(' + n + ', ' + t + ')'                                           # noqa
-            kevm.symbol_table['binRuntime']     = lambda s: '#binRuntime(' + s + ')'                                                        # noqa
-            kevm.symbol_table['abi_selector']   = lambda s: 'selector(' + s + ')'                                                           # noqa
+            kevm.symbol_table['hashedLocation']                 = lambda lang, base, offset: '#hashedLocation(' + lang + ', ' + base + ', ' + offset + ')'  # noqa
+            kevm.symbol_table['abiCallData']                    = lambda fname, *args: '#abiCallData(' + fname + "".join(", " + arg for arg in args) + ')'  # noqa
+            kevm.symbol_table['address']                        = _typed_arg_unparser('address')                                                            # noqa
+            kevm.symbol_table['bool']                           = _typed_arg_unparser('bool')                                                               # noqa
+            kevm.symbol_table['bytes']                          = _typed_arg_unparser('bytes')                                                              # noqa
+            kevm.symbol_table['bytes4']                         = _typed_arg_unparser('bytes4')                                                             # noqa
+            kevm.symbol_table['bytes32']                        = _typed_arg_unparser('bytes32')                                                            # noqa
+            kevm.symbol_table['int256']                         = _typed_arg_unparser('int256')                                                             # noqa
+            kevm.symbol_table['uint256']                        = _typed_arg_unparser('uint256')                                                            # noqa
+            kevm.symbol_table['rangeAddress']                   = lambda t: '#rangeAddress(' + t + ')'                                                      # noqa
+            kevm.symbol_table['rangeBool']                      = lambda t: '#rangeBool(' + t + ')'                                                         # noqa
+            kevm.symbol_table['rangeBytes']                     = lambda n, t: '#rangeBytes(' + n + ', ' + t + ')'                                          # noqa
+            kevm.symbol_table['rangeUInt']                      = lambda n, t: '#rangeUInt(' + n + ', ' + t + ')'                                           # noqa
+            kevm.symbol_table['rangeSInt']                      = lambda n, t: '#rangeSInt(' + n + ', ' + t + ')'                                           # noqa
+            kevm.symbol_table['binRuntime']                     = lambda s: '#binRuntime(' + s + ')'                                                        # noqa
+            kevm.symbol_table['abi_selector']                   = lambda s: 'selector(' + s + ')'                                                           # noqa
+            kevm.symbol_table[f'contract_{args.contract_name}'] = lambda: args.contract_name                                                                # noqa
 
             empty_config = KDefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
 

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -55,23 +55,22 @@ def main():
         else:
             kevm = KEVM(args.definition_dir)
 
-            kevm.symbol_table['hashedLocation']                 = lambda lang, base, offset: '#hashedLocation(' + lang + ', ' + base + ', ' + offset + ')'  # noqa
-            kevm.symbol_table['abiCallData']                    = lambda fname, *args: '#abiCallData(' + fname + "".join(", " + arg for arg in args) + ')'  # noqa
-            kevm.symbol_table['address']                        = _typed_arg_unparser('address')                                                            # noqa
-            kevm.symbol_table['bool']                           = _typed_arg_unparser('bool')                                                               # noqa
-            kevm.symbol_table['bytes']                          = _typed_arg_unparser('bytes')                                                              # noqa
-            kevm.symbol_table['bytes4']                         = _typed_arg_unparser('bytes4')                                                             # noqa
-            kevm.symbol_table['bytes32']                        = _typed_arg_unparser('bytes32')                                                            # noqa
-            kevm.symbol_table['int256']                         = _typed_arg_unparser('int256')                                                             # noqa
-            kevm.symbol_table['uint256']                        = _typed_arg_unparser('uint256')                                                            # noqa
-            kevm.symbol_table['rangeAddress']                   = lambda t: '#rangeAddress(' + t + ')'                                                      # noqa
-            kevm.symbol_table['rangeBool']                      = lambda t: '#rangeBool(' + t + ')'                                                         # noqa
-            kevm.symbol_table['rangeBytes']                     = lambda n, t: '#rangeBytes(' + n + ', ' + t + ')'                                          # noqa
-            kevm.symbol_table['rangeUInt']                      = lambda n, t: '#rangeUInt(' + n + ', ' + t + ')'                                           # noqa
-            kevm.symbol_table['rangeSInt']                      = lambda n, t: '#rangeSInt(' + n + ', ' + t + ')'                                           # noqa
-            kevm.symbol_table['binRuntime']                     = lambda s: '#binRuntime(' + s + ')'                                                        # noqa
-            kevm.symbol_table['abi_selector']                   = lambda s: 'selector(' + s + ')'                                                           # noqa
-            kevm.symbol_table[f'contract_{args.contract_name}'] = lambda: args.contract_name                                                                # noqa
+            kevm.symbol_table['hashedLocation'] = lambda lang, base, offset: '#hashedLocation(' + lang + ', ' + base + ', ' + offset + ')'  # noqa
+            kevm.symbol_table['abiCallData']    = lambda fname, *args: '#abiCallData(' + fname + "".join(", " + arg for arg in args) + ')'  # noqa
+            kevm.symbol_table['address']        = _typed_arg_unparser('address')                                                            # noqa
+            kevm.symbol_table['bool']           = _typed_arg_unparser('bool')                                                               # noqa
+            kevm.symbol_table['bytes']          = _typed_arg_unparser('bytes')                                                              # noqa
+            kevm.symbol_table['bytes4']         = _typed_arg_unparser('bytes4')                                                             # noqa
+            kevm.symbol_table['bytes32']        = _typed_arg_unparser('bytes32')                                                            # noqa
+            kevm.symbol_table['int256']         = _typed_arg_unparser('int256')                                                             # noqa
+            kevm.symbol_table['uint256']        = _typed_arg_unparser('uint256')                                                            # noqa
+            kevm.symbol_table['rangeAddress']   = lambda t: '#rangeAddress(' + t + ')'                                                      # noqa
+            kevm.symbol_table['rangeBool']      = lambda t: '#rangeBool(' + t + ')'                                                         # noqa
+            kevm.symbol_table['rangeBytes']     = lambda n, t: '#rangeBytes(' + n + ', ' + t + ')'                                          # noqa
+            kevm.symbol_table['rangeUInt']      = lambda n, t: '#rangeUInt(' + n + ', ' + t + ')'                                           # noqa
+            kevm.symbol_table['rangeSInt']      = lambda n, t: '#rangeSInt(' + n + ', ' + t + ')'                                           # noqa
+            kevm.symbol_table['binRuntime']     = lambda s: '#binRuntime(' + s + ')'                                                        # noqa
+            kevm.symbol_table['abi_selector']   = lambda s: 'selector(' + s + ')'                                                           # noqa
 
             empty_config = KDefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
 

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -3,7 +3,7 @@ import glob
 import json
 import logging
 import sys
-from typing import Final, List
+from typing import Any, Dict, Final, List
 
 from pyk.cli_utils import dir_path, file_path
 from pyk.kast import KDefinition, KFlatModule, KImport, KRequire
@@ -18,6 +18,27 @@ _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
 
 def main():
+
+    def _make_unparsing(symbol_table: Dict[str, Any], contract_names: List[str]) -> None:
+        symbol_table['hashedLocation'] = lambda lang, base, offset: '#hashedLocation(' + lang + ', ' + base + ', ' + offset + ')'  # noqa
+        symbol_table['abiCallData']    = lambda fname, *args: '#abiCallData(' + fname + "".join(", " + arg for arg in args) + ')'  # noqa
+        symbol_table['address']        = _typed_arg_unparser('address')                                                            # noqa
+        symbol_table['bool']           = _typed_arg_unparser('bool')                                                               # noqa
+        symbol_table['bytes']          = _typed_arg_unparser('bytes')                                                              # noqa
+        symbol_table['bytes4']         = _typed_arg_unparser('bytes4')                                                             # noqa
+        symbol_table['bytes32']        = _typed_arg_unparser('bytes32')                                                            # noqa
+        symbol_table['int256']         = _typed_arg_unparser('int256')                                                             # noqa
+        symbol_table['uint256']        = _typed_arg_unparser('uint256')                                                            # noqa
+        symbol_table['rangeAddress']   = lambda t: '#rangeAddress(' + t + ')'                                                      # noqa
+        symbol_table['rangeBool']      = lambda t: '#rangeBool(' + t + ')'                                                         # noqa
+        symbol_table['rangeBytes']     = lambda n, t: '#rangeBytes(' + n + ', ' + t + ')'                                          # noqa
+        symbol_table['rangeUInt']      = lambda n, t: '#rangeUInt(' + n + ', ' + t + ')'                                           # noqa
+        symbol_table['rangeSInt']      = lambda n, t: '#rangeSInt(' + n + ', ' + t + ')'                                           # noqa
+        symbol_table['binRuntime']     = lambda s: '#binRuntime(' + s + ')'                                                        # noqa
+        symbol_table['abi_selector']   = lambda s: 'selector(' + s + ')'                                                           # noqa
+        for cname in contract_names:
+            clabel = f'contract_{cname}'
+            symbol_table[clabel] = lambda: cname
 
     def _typed_arg_unparser(type_label: str):
         return lambda x: '#' + type_label + '(' + x + ')'
@@ -55,23 +76,6 @@ def main():
         else:
             kevm = KEVM(args.definition_dir)
 
-            kevm.symbol_table['hashedLocation'] = lambda lang, base, offset: '#hashedLocation(' + lang + ', ' + base + ', ' + offset + ')'  # noqa
-            kevm.symbol_table['abiCallData']    = lambda fname, *args: '#abiCallData(' + fname + "".join(", " + arg for arg in args) + ')'  # noqa
-            kevm.symbol_table['address']        = _typed_arg_unparser('address')                                                            # noqa
-            kevm.symbol_table['bool']           = _typed_arg_unparser('bool')                                                               # noqa
-            kevm.symbol_table['bytes']          = _typed_arg_unparser('bytes')                                                              # noqa
-            kevm.symbol_table['bytes4']         = _typed_arg_unparser('bytes4')                                                             # noqa
-            kevm.symbol_table['bytes32']        = _typed_arg_unparser('bytes32')                                                            # noqa
-            kevm.symbol_table['int256']         = _typed_arg_unparser('int256')                                                             # noqa
-            kevm.symbol_table['uint256']        = _typed_arg_unparser('uint256')                                                            # noqa
-            kevm.symbol_table['rangeAddress']   = lambda t: '#rangeAddress(' + t + ')'                                                      # noqa
-            kevm.symbol_table['rangeBool']      = lambda t: '#rangeBool(' + t + ')'                                                         # noqa
-            kevm.symbol_table['rangeBytes']     = lambda n, t: '#rangeBytes(' + n + ', ' + t + ')'                                          # noqa
-            kevm.symbol_table['rangeUInt']      = lambda n, t: '#rangeUInt(' + n + ', ' + t + ')'                                           # noqa
-            kevm.symbol_table['rangeSInt']      = lambda n, t: '#rangeSInt(' + n + ', ' + t + ')'                                           # noqa
-            kevm.symbol_table['binRuntime']     = lambda s: '#binRuntime(' + s + ')'                                                        # noqa
-            kevm.symbol_table['abi_selector']   = lambda s: 'selector(' + s + ')'                                                           # noqa
-
             empty_config = KDefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
 
             if args.command == 'solc-to-k':
@@ -79,35 +83,33 @@ def main():
                 contract_json = solc_json['contracts'][args.contract_file.name][args.contract_name]
                 contract_module = contract_to_k(contract_json, args.contract_name, args.generate_storage, empty_config)
                 bin_runtime_definition = KDefinition(contract_module.name, [contract_module], requires=[KRequire('edsl.md')])
-                clabel = f'contract_{args.contract_name}'
-                kevm.symbol_table[clabel] = lambda: args.contract_name
+                _make_unparsing(kevm.symbol_table, [args.contract_name])
                 print(kevm.pretty_print(bin_runtime_definition) + '\n')
 
             elif args.command == 'foundry-to-k':
                 path_glob = str(args.out) + '/**/*.json'
                 modules: List[KFlatModule] = []
+                contract_names: List[str] = []
                 # Must sort to get consistent output order on different platforms.
                 for json_file in sorted(glob.glob(path_glob)):
                     _LOGGER.info(f'Processing contract file: {json_file}')
                     contract_name = json_file.split('/')[-1]
                     contract_name = contract_name[0:-5] if contract_name.endswith('.json') else contract_name
+                    contract_names.append(contract_name)
                     with open(json_file, 'r') as cjson:
                         contract_json = json.loads(cjson.read())
                         module = contract_to_k(contract_json, contract_name, args.generate_storage, empty_config, foundry=True)
-                        clabel = f'contract_{contract_name}'
-                        kevm.symbol_table[clabel] = lambda: contract_name
                         _LOGGER.info(f'Produced contract module: {module.name}')
                         modules.append(module)
                 main_module = KFlatModule(args.main_module, [], [KImport(module.name) for module in modules])
                 modules.append(main_module)
                 bin_runtime_definition = KDefinition(main_module.name, modules, requires=[KRequire('edsl.md')])
+                _make_unparsing(kevm.symbol_table, contract_names)
                 print(kevm.pretty_print(bin_runtime_definition) + '\n')
 
             elif args.command == 'gen-spec-modules':
                 defn, contract_names = gen_spec_modules(kevm, args.spec_module_name)
-                for cname in contract_names:
-                    clabel = f'contract_{contract_name}'
-                    kevm.symbol_table[clabel] = lambda: cname
+                _make_unparsing(kevm.symbol_table, contract_names)
                 print(kevm.pretty_print(defn) + '\n')
 
             elif args.command == 'prove':

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -104,7 +104,8 @@ def main():
             elif args.command == 'gen-spec-modules':
                 defn, contract_names = gen_spec_modules(kevm, args.spec_module_name)
                 for cname in contract_names:
-                    kevm.symbol_table[cname] = lambda: cname
+                    clabel = f'contract_{contract_name}'
+                    kevm.symbol_table[clabel] = lambda: cname
                 print(kevm.pretty_print(defn) + '\n')
 
             elif args.command == 'prove':

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -7,10 +7,11 @@ from typing import Final, List
 
 from pyk.cli_utils import dir_path, file_path
 from pyk.kast import KDefinition, KFlatModule, KImport, KRequire
+from pyk.prelude import Sorts
 
 from .kevm import KEVM
 from .solc_to_k import contract_to_k, gen_spec_modules, solc_compile
-from .utils import add_include_arg
+from .utils import KDefinition_empty_config, add_include_arg
 
 _LOGGER: Final = logging.getLogger(__name__)
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
@@ -71,10 +72,12 @@ def main():
             kevm.symbol_table['binRuntime']     = lambda s: '#binRuntime(' + s + ')'                                                        # noqa
             kevm.symbol_table['abi_selector']   = lambda s: 'selector(' + s + ')'                                                           # noqa
 
+            empty_config = KDefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
+
             if args.command == 'solc-to-k':
                 solc_json = solc_compile(args.contract_file)
                 contract_json = solc_json['contracts'][args.contract_file.name][args.contract_name]
-                contract_module = contract_to_k(contract_json, args.contract_name, args.generate_storage)
+                contract_module = contract_to_k(contract_json, args.contract_name, args.generate_storage, empty_config)
                 bin_runtime_definition = KDefinition(contract_module.name, [contract_module], requires=[KRequire('edsl.md')])
                 kevm.symbol_table[args.contract_name] = lambda: args.contract_name
                 print(kevm.pretty_print(bin_runtime_definition) + '\n')
@@ -89,7 +92,7 @@ def main():
                     contract_name = contract_name[0:-5] if contract_name.endswith('.json') else contract_name
                     with open(json_file, 'r') as cjson:
                         contract_json = json.loads(cjson.read())
-                        module = contract_to_k(contract_json, contract_name, args.generate_storage, foundry=True)
+                        module = contract_to_k(contract_json, contract_name, args.generate_storage, empty_config, foundry=True)
                         kevm.symbol_table[contract_name] = lambda: contract_name
                         _LOGGER.info(f'Produced contract module: {module.name}')
                         modules.append(module)

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -102,8 +102,10 @@ def main():
                 print(kevm.pretty_print(bin_runtime_definition) + '\n')
 
             elif args.command == 'gen-spec-modules':
-                res = gen_spec_modules(kevm, args.spec_module_name)
-                print(res)
+                defn, contract_names = gen_spec_modules(kevm, args.spec_module_name)
+                for cname in contract_names:
+                    kevm.symbol_table[cname] = lambda: cname
+                print(kevm.pretty_print(defn) + '\n')
 
             elif args.command == 'prove':
                 spec_file = args.spec_file

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -181,3 +181,7 @@ class KEVM(KProve):
     @staticmethod
     def wordstack_len(constrainedTerm: KInner) -> int:
         return len(flattenLabel('_:__EVM-TYPES_WordStack_Int_WordStack', getCell(constrainedTerm, 'WORDSTACK_CELL')))
+
+    @staticmethod
+    def parse_bytestack(s: KInner):
+        return KApply('#parseByteStack(_)_SERIALIZATION_ByteArray_String', [s])

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -149,9 +149,9 @@ class KEVM(KProve):
         return KApply('#binRuntime', [c])
 
     @staticmethod
-    def abi_calldata(n: str, args: List[KInner]):
-        token: KInner = stringToken(n)
-        return KApply('#abiCallData', [token] + args)
+    def abi_calldata(name: str, args: List[KInner]):
+        token: KInner = stringToken(name)
+        return KApply('#abiCallData(_,_)_EVM-ABI_ByteArray_String_TypedArgs', [token] + args)
 
     @staticmethod
     def abi_address(a: KInner) -> KApply:

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -154,6 +154,10 @@ class KEVM(KProve):
         return KApply('#abiCallData(_,_)_EVM-ABI_ByteArray_String_TypedArgs', [token] + args)
 
     @staticmethod
+    def abi_selector(name: str):
+        return KApply('abi_selector', [stringToken(name)])
+
+    @staticmethod
     def abi_address(a: KInner) -> KApply:
         return KApply('#address(_)_EVM-ABI_TypedArg_Int', [a])
 

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -6,12 +6,12 @@ from subprocess import CalledProcessError
 from typing import Any, Dict, Final, List, Optional
 
 from pyk.cli_utils import run_process
-from pyk.kast import KApply, KInner, KSort
+from pyk.kast import KApply, KInner
 from pyk.kastManip import flattenLabel, getCell
 from pyk.ktool import KProve, paren
 from pyk.prelude import intToken, stringToken
 
-from .utils import add_include_arg, build_empty_config_cell
+from .utils import add_include_arg
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -24,9 +24,6 @@ class KEVM(KProve):
     def __init__(self, kompiled_directory, main_file_name=None, use_directory=None):
         super().__init__(kompiled_directory, main_file_name=main_file_name, use_directory=use_directory)
         KEVM._patch_symbol_table(self.symbol_table)
-
-    def empty_config(self, top_cell: KSort = KSort('GeneratedTopCell')) -> KInner:
-        return build_empty_config_cell(self.definition, top_cell)
 
     @staticmethod
     def kompile(

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -85,31 +85,31 @@ class KEVM(KProve):
         symbol_table['_s<Word__EVM-TYPES_Int_Int_Int']                = paren(lambda a1, a2: '(' + a1 + ') s<Word (' + a2 + ')')            # noqa
 
     @staticmethod
-    def halt() -> KInner:
+    def halt() -> KApply:
         return KApply('#halt_EVM_KItem')
 
     @staticmethod
-    def execute() -> KInner:
+    def execute() -> KApply:
         return KApply('#execute_EVM_KItem')
 
     @staticmethod
-    def jumpi() -> KInner:
+    def jumpi() -> KApply:
         return KApply('JUMPI_EVM_BinStackOp')
 
     @staticmethod
-    def jump() -> KInner:
+    def jump() -> KApply:
         return KApply('JUMP_EVM_UnStackOp')
 
     @staticmethod
-    def jumpi_applied(pc: KInner, cond: KInner) -> KInner:
+    def jumpi_applied(pc: KInner, cond: KInner) -> KApply:
         return KApply('____EVM_InternalOp_BinStackOp_Int_Int', [KEVM.jumpi(), pc, cond])
 
     @staticmethod
-    def jump_applied(pc: KInner) -> KInner:
+    def jump_applied(pc: KInner) -> KApply:
         return KApply('___EVM_InternalOp_UnStackOp_Int', [KEVM.jump(), pc])
 
     @staticmethod
-    def pow256():
+    def pow256() -> KApply:
         return KApply('pow256_EVM-TYPES_Int', [])
 
     @staticmethod
@@ -129,7 +129,7 @@ class KEVM(KProve):
         return KApply('#rangeBool(_)_EVM-TYPES_Bool_Int', [i])
 
     @staticmethod
-    def bool_2_word(cond: KInner) -> KInner:
+    def bool_2_word(cond: KInner) -> KApply:
         return KApply('bool2Word(_)_EVM-TYPES_Int_Bool', [cond])
 
     @staticmethod
@@ -149,12 +149,12 @@ class KEVM(KProve):
         return KApply('#binRuntime', [c])
 
     @staticmethod
-    def abi_calldata(name: str, args: List[KInner]):
+    def abi_calldata(name: str, args: List[KInner]) -> KApply:
         token: KInner = stringToken(name)
         return KApply('#abiCallData(_,_)_EVM-ABI_ByteArray_String_TypedArgs', [token] + args)
 
     @staticmethod
-    def abi_selector(name: str):
+    def abi_selector(name: str) -> KApply:
         return KApply('abi_selector', [stringToken(name)])
 
     @staticmethod
@@ -187,5 +187,5 @@ class KEVM(KProve):
         return len(flattenLabel('_:__EVM-TYPES_WordStack_Int_WordStack', getCell(constrainedTerm, 'WORDSTACK_CELL')))
 
     @staticmethod
-    def parse_bytestack(s: KInner):
+    def parse_bytestack(s: KInner) -> KApply:
         return KApply('#parseByteStack(_)_SERIALIZATION_ByteArray_String', [s])

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -105,16 +105,14 @@ def gen_claims_for_contract(empty_config: KInner, contract_name: str) -> List[KC
     return [claim]
 
 
-def gen_spec_modules(kevm: KEVM, spec_module_name: str) -> str:
+def gen_spec_modules(kevm: KEVM, spec_module_name: str) -> Tuple[KDefinition, List[str]]:
     production_labels = [prod.klabel for module in kevm.definition for prod in module.productions if prod.klabel is not None]
     contract_names = [prod_label.name[9:] for prod_label in production_labels if prod_label.name.startswith('contract_')]
     empty_config = KDefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
-    for contract_name in contract_names:
-        claims.extend(gen_claims_for_contract(empty_config, contract_name)
-        kevm.symbol_table[contract_name] = lambda: contract_name
+    claims = [claim for contract_name in contract_names for claim in gen_claims_for_contract(empty_config, contract_name)]
     spec_module = KFlatModule(spec_module_name, claims, [KImport(kevm.definition.main_module_name)])
     spec_defn = KDefinition(spec_module_name, [spec_module], [KRequire('verification.k')])
-    return kevm.pretty_print(spec_defn)
+    return spec_defn, contract_names
 
 
 def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: bool, empty_config: KInner, foundry: bool = False) -> KFlatModule:

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -16,6 +16,7 @@ from pyk.kast import (
     KFlatModule,
     KImport,
     KInner,
+    KLabel,
     KNonTerminal,
     KProduction,
     KRequire,
@@ -232,7 +233,7 @@ def _extract_storage_sentences(contract_name, storage_sort, storage_layout):
 
 def generate_function_sentences(contract_name, contract_sort, abi):
     function_sort = KSort(f'{contract_name}Function')
-    function_call_data_production = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], att=KAtt({'klabel': f'function_{contract_name}', 'symbol': '', 'function': ''}))
+    function_call_data_production = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], att=KAtt({'symbol': '', 'function': ''}), klabel=KLabel(f'function_{contract_name}'))
     function_sentence_pairs = _extract_function_sentences(contract_name, function_sort, abi)
 
     if not function_sentence_pairs:
@@ -264,7 +265,7 @@ def _extract_function_sentences(contract_name, function_sort, abi):
         items += intersperse(input_nonterminals, KTerminal(','))
 
         items.append(KTerminal(')'))
-        return KProduction(function_sort, items)
+        return KProduction(function_sort, items, klabel=KLabel(f'{contract_name}_function_{name}'))
 
     def extract_rule(name, inputs):
         input_names = normalize_input_names([input_dict['name'] for input_dict in inputs])

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -133,7 +133,7 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
 
     contract_subsort = KProduction(KSort('Contract'), [KNonTerminal(contract_sort)])
     contract_production = KProduction(contract_sort, [KTerminal(contract_name)], att=KAtt({'klabel': f'contract_{contract_name}', 'symbol': ''}))
-    contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_name)]), _parseByteStack(stringToken(bin_runtime))))
+    contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_name)]), KEVM.parse_bytestack(stringToken(bin_runtime))))
 
     module_name = contract_name.upper() + '-BIN-RUNTIME'
     module = KFlatModule(
@@ -323,10 +323,6 @@ def _extract_function_sentences(contract_name, function_sort, abi) -> List[Tuple
         inputs = func_dict['inputs']
         res.append((extract_production(name, inputs), extract_rule(name, inputs)))
     return res
-
-
-def _parseByteStack(s: KInner):
-    return KApply('#parseByteStack(_)_SERIALIZATION_ByteArray_String', [s])
 
 
 def _check_supported_value_type(type_label: str) -> None:

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -115,7 +115,7 @@ def gen_spec_modules(kevm: KEVM, spec_module_name: str) -> Tuple[KDefinition, Li
     return spec_defn, contract_names
 
 
-def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: bool, empty_config: KInner, foundry: bool = False) -> KFlatModule:
+def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: bool, foundry: bool = False) -> KFlatModule:
 
     abi = contract_json['abi']
     hashes = contract_json['evm']['methodIdentifiers'] if not foundry else contract_json['methodIdentifiers']

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -254,7 +254,7 @@ def generate_function_selector_alias_sentences(contract_name, contract_sort, has
     for h in hashes:
         f_name = h.split('(')[0]
         hash_int = int(hashes[h], 16)
-        abi_function_selector_rewrite = KRewrite(KApply('abi_selector', [stringToken(f'{f_name}')]), intToken(hash_int))
+        abi_function_selector_rewrite = KRewrite(KEVM.abi_selector(f_name), intToken(hash_int))
         abi_function_selector_rules.append(KRule(abi_function_selector_rewrite))
     return abi_function_selector_rules
 

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -131,9 +131,10 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
     function_sentences = [function_call_data_production] + function_productions + function_rules
     function_selector_alias_sentences = generate_function_selector_alias_sentences(contract_name, contract_sort, hashes)
 
+    contract_klabel = KLabel(f'contract_{contract_name}')
     contract_subsort = KProduction(KSort('Contract'), [KNonTerminal(contract_sort)])
-    contract_production = KProduction(contract_sort, [KTerminal(contract_name)], att=KAtt({'klabel': f'contract_{contract_name}', 'symbol': ''}))
-    contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_name)]), KEVM.parse_bytestack(stringToken(bin_runtime))))
+    contract_production = KProduction(contract_sort, [KTerminal(contract_name)], klabel=contract_klabel)
+    contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_klabel)]), KEVM.parse_bytestack(stringToken(bin_runtime))))
 
     module_name = contract_name.upper() + '-BIN-RUNTIME'
     module = KFlatModule(

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -127,8 +127,7 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
     if generate_storage:
         storage_layout = contract_json['storageLayout']
         storage_sentences = generate_storage_sentences(contract_name, contract_sort, storage_layout)
-    function_call_data_production, function_productions, function_rules = generate_function_sentences(contract_name, contract_sort, abi)
-    function_sentences = [function_call_data_production] + function_productions + function_rules
+    function_sentences = generate_function_sentences(contract_name, contract_sort, abi)
     function_selector_alias_sentences = generate_function_selector_alias_sentences(contract_name, contract_sort, hashes)
 
     contract_klabel = KLabel(f'contract_{contract_name}')

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -109,7 +109,9 @@ def gen_spec_modules(kevm: KEVM, spec_module_name: str) -> str:
     production_labels = [prod.klabel for module in kevm.definition for prod in module.productions if prod.klabel is not None]
     contract_names = [prod_label.name[9:] for prod_label in production_labels if prod_label.name.startswith('contract_')]
     empty_config = KDefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
-    claims = [claim for name in contract_names for claim in gen_claims_for_contract(empty_config, name)]
+    for contract_name in contract_names:
+        claims.extend(gen_claims_for_contract(empty_config, contract_name)
+        kevm.symbol_table[contract_name] = lambda: contract_name
     spec_module = KFlatModule(spec_module_name, claims, [KImport(kevm.definition.main_module_name)])
     spec_defn = KDefinition(spec_module_name, [spec_module], [KRequire('verification.k')])
     return kevm.pretty_print(spec_defn)

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -27,7 +27,7 @@ from pyk.kast import (
     KToken,
     KVariable,
 )
-from pyk.kastManip import build_rule, remove_generated_cells, substitute
+from pyk.kastManip import build_rule, substitute
 from pyk.prelude import Sorts, intToken, stringToken
 from pyk.utils import intersperse
 
@@ -75,7 +75,7 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
 
 
 def gen_claims_for_contract(defn: KDefinition, contract_name: str) -> List[KClaim]:
-    empty_config = remove_generated_cells(kdefinition_empty_config(defn, Sorts.GENERATED_TOP_CELL))
+    empty_config = kdefinition_empty_config(defn, Sorts.GENERATED_TOP_CELL)
     program = KApply('binRuntime', [KApply('contract_' + contract_name)])
     account_cell = KEVM.account_cell(KVariable('ACCT_ID'), KVariable('ACCT_BALANCE'), program, KVariable('ACCT_STORAGE'), KVariable('ACCT_ORIGSTORAGE'), KVariable('ACCT_NONCE'))
     init_subst = {

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -22,6 +22,7 @@ from pyk.kast import (
     KRequire,
     KRewrite,
     KRule,
+    KSentence,
     KSequence,
     KSort,
     KTerminal,
@@ -126,7 +127,8 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
     if generate_storage:
         storage_layout = contract_json['storageLayout']
         storage_sentences = generate_storage_sentences(contract_name, contract_sort, storage_layout)
-    function_sentences = generate_function_sentences(contract_name, contract_sort, abi)
+    function_call_data_production, function_productions, function_rules = generate_function_sentences(contract_name, contract_sort, abi)
+    function_sentences = [function_call_data_production] + function_productions + function_rules
     function_selector_alias_sentences = generate_function_selector_alias_sentences(contract_name, contract_sort, hashes)
 
     contract_subsort = KProduction(KSort('Contract'), [KNonTerminal(contract_sort)])
@@ -231,16 +233,19 @@ def _extract_storage_sentences(contract_name, storage_sort, storage_layout):
     return recur_struct([], f'{contract_name}', intToken('0'), 0, storage, gen_dot=False)
 
 
-def generate_function_sentences(contract_name, contract_sort, abi):
+def generate_function_sentences(contract_name: str, contract_sort: KSort, abi):
     function_sort = KSort(f'{contract_name}Function')
-    function_call_data_production = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], att=KAtt({'symbol': '', 'function': ''}), klabel=KLabel(f'function_{contract_name}'))
+    function_call_data_production: KSentence = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], att=KAtt({'symbol': '', 'function': ''}), klabel=KLabel(f'function_{contract_name}'))
     function_sentence_pairs = _extract_function_sentences(contract_name, function_sort, abi)
 
-    if not function_sentence_pairs:
-        return []
+    function_productions: List[KSentence] = []
+    function_rules: List[KSentence] = []
+    for f_prod, f_rule in function_sentence_pairs:
+        function_productions.append(f_prod)
+        function_rules.append(f_rule)
 
-    function_productions, function_rules = map(list, zip(*function_sentence_pairs))
-    return [function_call_data_production] + function_productions + function_rules
+    function_sentences = function_productions + function_rules
+    return [function_call_data_production] + function_sentences if function_sentences else []
 
 
 def generate_function_selector_alias_sentences(contract_name, contract_sort, hashes):
@@ -253,7 +258,7 @@ def generate_function_selector_alias_sentences(contract_name, contract_sort, has
     return abi_function_selector_rules
 
 
-def _extract_function_sentences(contract_name, function_sort, abi):
+def _extract_function_sentences(contract_name, function_sort, abi) -> List[Tuple[KProduction, KRule]]:
     def extract_production(name, inputs):
         input_types = [input_dict['type'] for input_dict in inputs]
 

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -28,11 +28,11 @@ from pyk.kast import (
     KVariable,
 )
 from pyk.kastManip import build_rule, remove_generated_cells, substitute
-from pyk.prelude import intToken, stringToken
+from pyk.prelude import Sorts, intToken, stringToken
 from pyk.utils import intersperse
 
 from .kevm import KEVM
-from .utils import abstract_cell_vars
+from .utils import abstract_cell_vars, kdefinition_empty_config
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -74,8 +74,8 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
     return json.loads(process_res.stdout)
 
 
-def gen_claims_for_contract(kevm: KEVM, contract_name: str) -> List[KClaim]:
-    empty_config = remove_generated_cells(kevm.empty_config())
+def gen_claims_for_contract(defn: KDefinition, contract_name: str) -> List[KClaim]:
+    empty_config = remove_generated_cells(kdefinition_empty_config(defn, Sorts.GENERATED_TOP_CELL))
     program = KApply('binRuntime', [KApply('contract_' + contract_name)])
     account_cell = KEVM.account_cell(KVariable('ACCT_ID'), KVariable('ACCT_BALANCE'), program, KVariable('ACCT_STORAGE'), KVariable('ACCT_ORIGSTORAGE'), KVariable('ACCT_NONCE'))
     init_subst = {
@@ -107,7 +107,7 @@ def gen_claims_for_contract(kevm: KEVM, contract_name: str) -> List[KClaim]:
 def gen_spec_modules(kevm: KEVM, spec_module_name: str) -> str:
     production_labels = [prod.klabel for module in kevm.definition for prod in module.productions if prod.klabel is not None]
     contract_names = [prod_label.name[9:] for prod_label in production_labels if prod_label.name.startswith('contract_')]
-    claims = [claim for name in contract_names for claim in gen_claims_for_contract(kevm, name)]
+    claims = [claim for name in contract_names for claim in gen_claims_for_contract(kevm.definition, name)]
     spec_module = KFlatModule(spec_module_name, claims, [KImport(kevm.definition.main_module_name)])
     spec_defn = KDefinition(spec_module_name, [spec_module], [KRequire('verification.k')])
     return kevm.pretty_print(spec_defn)

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -282,7 +282,7 @@ def _extract_function_sentences(contract_name, function_sort, abi):
 
     def extract_rhs(name, input_names, input_types):
         args = [KApply('abi_type_' + input_type, [KVariable(input_name)]) for input_name, input_type in zip(input_names, input_types)] or [KToken('.TypedArgs', 'TypedArgs')]
-        return KApply('abiCallData', [stringToken(name)] + args)
+        return KEVM.abi_calldata(name, args)
 
     def extract_ensures(input_names, input_types):
         opt_conjuncts = [_range_predicate(KVariable(input_name), input_type) for input_name, input_type in zip(input_names, input_types)]

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -74,8 +74,7 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
     return json.loads(process_res.stdout)
 
 
-def gen_claims_for_contract(defn: KDefinition, contract_name: str) -> List[KClaim]:
-    empty_config = kdefinition_empty_config(defn, Sorts.GENERATED_TOP_CELL)
+def gen_claims_for_contract(empty_config: KInner, contract_name: str) -> List[KClaim]:
     program = KApply('binRuntime', [KApply('contract_' + contract_name)])
     account_cell = KEVM.account_cell(KVariable('ACCT_ID'), KVariable('ACCT_BALANCE'), program, KVariable('ACCT_STORAGE'), KVariable('ACCT_ORIGSTORAGE'), KVariable('ACCT_NONCE'))
     init_subst = {
@@ -107,7 +106,8 @@ def gen_claims_for_contract(defn: KDefinition, contract_name: str) -> List[KClai
 def gen_spec_modules(kevm: KEVM, spec_module_name: str) -> str:
     production_labels = [prod.klabel for module in kevm.definition for prod in module.productions if prod.klabel is not None]
     contract_names = [prod_label.name[9:] for prod_label in production_labels if prod_label.name.startswith('contract_')]
-    claims = [claim for name in contract_names for claim in gen_claims_for_contract(kevm.definition, name)]
+    empty_config = kdefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
+    claims = [claim for name in contract_names for claim in gen_claims_for_contract(empty_config, name)]
     spec_module = KFlatModule(spec_module_name, claims, [KImport(kevm.definition.main_module_name)])
     spec_defn = KDefinition(spec_module_name, [spec_module], [KRequire('verification.k')])
     return kevm.pretty_print(spec_defn)

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -3,7 +3,7 @@ import json
 import logging
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Any, Dict, Final, List
+from typing import Any, Dict, Final, List, Tuple
 
 from pyk.cli_utils import run_process
 from pyk.cterm import CTerm
@@ -34,7 +34,7 @@ from pyk.prelude import Sorts, intToken, stringToken
 from pyk.utils import intersperse
 
 from .kevm import KEVM
-from .utils import abstract_cell_vars, kdefinition_empty_config
+from .utils import KDefinition_empty_config, abstract_cell_vars
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -108,14 +108,14 @@ def gen_claims_for_contract(empty_config: KInner, contract_name: str) -> List[KC
 def gen_spec_modules(kevm: KEVM, spec_module_name: str) -> str:
     production_labels = [prod.klabel for module in kevm.definition for prod in module.productions if prod.klabel is not None]
     contract_names = [prod_label.name[9:] for prod_label in production_labels if prod_label.name.startswith('contract_')]
-    empty_config = kdefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
+    empty_config = KDefinition_empty_config(kevm.definition, Sorts.GENERATED_TOP_CELL)
     claims = [claim for name in contract_names for claim in gen_claims_for_contract(empty_config, name)]
     spec_module = KFlatModule(spec_module_name, claims, [KImport(kevm.definition.main_module_name)])
     spec_defn = KDefinition(spec_module_name, [spec_module], [KRequire('verification.k')])
     return kevm.pretty_print(spec_defn)
 
 
-def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: bool, foundry: bool = False) -> KFlatModule:
+def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: bool, empty_config: KInner, foundry: bool = False) -> KFlatModule:
 
     abi = contract_json['abi']
     hashes = contract_json['evm']['methodIdentifiers'] if not foundry else contract_json['methodIdentifiers']

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -235,7 +235,7 @@ def _extract_storage_sentences(contract_name, storage_sort, storage_layout):
 
 def generate_function_sentences(contract_name: str, contract_sort: KSort, abi):
     function_sort = KSort(f'{contract_name}Function')
-    function_call_data_production: KSentence = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], att=KAtt({'symbol': '', 'function': ''}), klabel=KLabel(f'function_{contract_name}'))
+    function_call_data_production: KSentence = KProduction(KSort('ByteArray'), [KNonTerminal(contract_sort), KTerminal('.'), KNonTerminal(function_sort)], klabel=KLabel(f'function_{contract_name}'), att=KAtt({'function': ''}))
     function_sentence_pairs = _extract_function_sentences(contract_name, function_sort, abi)
 
     function_productions: List[KSentence] = []

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -2,7 +2,9 @@ from pyk.kast import (
     KApply,
     KDefinition,
     KInner,
+    KLabel,
     KNonTerminal,
+    KProduction,
     KSort,
     KTerminal,
     KVariable,
@@ -39,6 +41,13 @@ def KDefinition_empty_config(definition: KDefinition, sort: KSort) -> KInner:
         return KApply(label, args)
 
     return remove_generated_cells(_kdefinition_empty_config(sort))
+
+
+def KDefinition_production_for_label(definition: KDefinition, klabel: KLabel) -> KProduction:
+    productions = [prod for prod in definition.syntax_productions if prod.klabel == klabel]
+    if len(productions) != 1:
+        raise ValueError(f'Did not find unique production for klabel {klabel}: {productions}')
+    return productions[0]
 
 
 def add_include_arg(includes):

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -44,7 +44,7 @@ def get_label_for_cell_sorts(definition, sort):
     return productions[0].klabel
 
 
-def build_empty_config_cell(definition, sort):
+def kdefinition_empty_config(definition, sort):
     label = get_label_for_cell_sorts(definition, sort)
     production = get_production_for_klabel(definition, label)
     args = []
@@ -54,7 +54,7 @@ def build_empty_config_cell(definition, sort):
         if type(p_item) is KNonTerminal:
             num_nonterminals += 1
             if p_item.sort.name.endswith('Cell'):
-                args.append(build_empty_config_cell(definition, p_item.sort))
+                args.append(kdefinition_empty_config(definition, p_item.sort))
             else:
                 num_freshvars += 1
                 args.append(KVariable(sort.name[0:-4].upper() + '_CELL'))

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -17,6 +17,30 @@ from pyk.kastManip import (
 )
 
 
+def KDefinition_empty_config(definition: KDefinition, sort: KSort) -> KInner:
+
+    def _kdefinition_empty_config(_sort):
+        label = get_label_for_cell_sorts(definition, _sort)
+        production = get_production_for_klabel(definition, label)
+        args = []
+        num_nonterminals = 0
+        num_freshvars = 0
+        for p_item in production.items:
+            if type(p_item) is KNonTerminal:
+                num_nonterminals += 1
+                if p_item.sort.name.endswith('Cell'):
+                    args.append(_kdefinition_empty_config(p_item.sort))
+                else:
+                    num_freshvars += 1
+                    args.append(KVariable(_sort.name[0:-4].upper() + '_CELL'))
+        if num_nonterminals > 1 and num_freshvars > 0:
+            sort_name = sort.name
+            raise ValueError(f'Found mixed cell and non-cell arguments to cell constructor for {sort_name}!')
+        return KApply(label, args)
+
+    return remove_generated_cells(_kdefinition_empty_config(sort))
+
+
 def add_include_arg(includes):
     return [arg for include in includes for arg in ['-I', include]]
 
@@ -51,27 +75,3 @@ def get_label_for_cell_sorts(definition, sort):
     if len(productions) != 1:
         raise ValueError(f'Expected 1 production for sort {sort}, not {productions}!')
     return productions[0].klabel
-
-
-def kdefinition_empty_config(definition: KDefinition, sort: KSort) -> KInner:
-
-    def _kdefinition_empty_config(_sort):
-        label = get_label_for_cell_sorts(definition, _sort)
-        production = get_production_for_klabel(definition, label)
-        args = []
-        num_nonterminals = 0
-        num_freshvars = 0
-        for p_item in production.items:
-            if type(p_item) is KNonTerminal:
-                num_nonterminals += 1
-                if p_item.sort.name.endswith('Cell'):
-                    args.append(_kdefinition_empty_config(p_item.sort))
-                else:
-                    num_freshvars += 1
-                    args.append(KVariable(_sort.name[0:-4].upper() + '_CELL'))
-        if num_nonterminals > 1 and num_freshvars > 0:
-            sort_name = sort.name
-            raise ValueError(f'Found mixed cell and non-cell arguments to cell constructor for {sort_name}!')
-        return KApply(label, args)
-
-    return remove_generated_cells(_kdefinition_empty_config(sort))

--- a/tests/gen-spec/foundry/bin-runtime.k.check.expected
+++ b/tests/gen-spec/foundry/bin-runtime.k.check.expected
@@ -5,9 +5,9 @@ module CONTRACT-BIN-RUNTIME
     
     syntax Contract ::= ContractContract 
     
-    syntax ContractContract ::= "Contract" [klabel(contract_Contract), symbol()]
+    syntax ContractContract ::= "Contract" [klabel(contract_Contract)]
     
-    rule  ( #binRuntime(ContractTest) => #parseByteStack ( "0x0x6080604052600080fdfea2646970667358221220febf745518acc26f684d27983160459fa2f213f0d4664cb72e4e8885a5fc079664736f6c634300080f0033" ) )
+    rule  ( #binRuntime(Contract) => #parseByteStack ( "0x0x6080604052600080fdfea2646970667358221220febf745518acc26f684d27983160459fa2f213f0d4664cb72e4e8885a5fc079664736f6c634300080f0033" ) )
       
 
 endmodule
@@ -17,23 +17,23 @@ module CONTRACTTEST-BIN-RUNTIME
     
     syntax Contract ::= ContractTestContract 
     
-    syntax ContractTestContract ::= "ContractTest" [klabel(contract_ContractTest), symbol()]
+    syntax ContractTestContract ::= "ContractTest" [klabel(contract_ContractTest)]
     
-    syntax ByteArray ::= ContractTestContract "." ContractTestFunction [klabel(function_ContractTest), symbol(), function()]
+    syntax ByteArray ::= ContractTestContract "." ContractTestFunction [function(), klabel(function_ContractTest)]
     
-    syntax ContractTestFunction ::= "setUp" "(" ")" 
+    syntax ContractTestFunction ::= "setUp" "(" ")" [klabel(ContractTest_function_setUp)]
     
-    syntax ContractTestFunction ::= "test_1" "(" ")" 
+    syntax ContractTestFunction ::= "test_1" "(" ")" [klabel(ContractTest_function_test_1)]
     
-    syntax ContractTestFunction ::= "test_2" "(" ")" 
+    syntax ContractTestFunction ::= "test_2" "(" ")" [klabel(ContractTest_function_test_2)]
     
-    rule  ( ContractTest.setUp() => #abiCallData("setUp", .TypedArgs) )
+    rule  ( ContractTest.setUp() => #abiCallData ( "setUp" , .TypedArgs ) )
       
     
-    rule  ( ContractTest.test_1() => #abiCallData("test_1", .TypedArgs) )
+    rule  ( ContractTest.test_1() => #abiCallData ( "test_1" , .TypedArgs ) )
       
     
-    rule  ( ContractTest.test_2() => #abiCallData("test_2", .TypedArgs) )
+    rule  ( ContractTest.test_2() => #abiCallData ( "test_2" , .TypedArgs ) )
       
     
     rule  ( #binRuntime(ContractTest) => #parseByteStack ( "0x0x6080604052348015600f57600080fd5b5060043610603c5760003560e01c80630a9254e4146041578063663bc990146041578063899eb49c146043575b600080fd5b005b6041604b565b565b6049634e487b7160e01b600052600160045260246000fdfea264697066735822122088b9c698d4d8963d9636778228b7adb6c08b645395e41f0e34b84090ec109da464736f6c634300080f0033" ) )

--- a/tests/gen-spec/mcd-spec.k.check.expected
+++ b/tests/gen-spec/mcd-spec.k.check.expected
@@ -1341,3 +1341,4 @@ module MCD-SPEC
       [label(spotter)]
 
 endmodule
+

--- a/tests/specs/foundry/foundry-spec.k.check.expected
+++ b/tests/specs/foundry/foundry-spec.k.check.expected
@@ -386,3 +386,4 @@ module FOUNDRY-SPEC
       [label(contract)]
 
 endmodule
+


### PR DESCRIPTION
These are the changes I could pull out from https://github.com/runtimeverification/evm-semantics/pull/1285 without breaking tests.

- Function `KDefinition_empty_config` is pulled out and updated from `build_empty_config_cell`.
- Several functions which took `KEVM` as input now just take an empty configuration as input.
- KLabels used for contract names are fixed.
- Several `symbol` attributes are removed (uneeded).
- Typing in several places is tightened up.
- Static methods `KEVM.parse_bytestack` and `KEVM.abi_selector` are pulled out.
- Symbol table adjustments are pulled out into common function `_make_unparsing`
- Function `KDefinition_get_production_for_label` is pulled out from KSummarize repo, and asserts uniqueness of the production too.
- Verbose output is turned on in Makefile for kevm-pyk tests.