### PR TITLE
Less hacky unparsing

### DIFF
--- a/edsl.md
+++ b/edsl.md
@@ -19,10 +19,11 @@ module EDSL
     imports EVM-ABI
     imports EVM-OPTIMIZATIONS
     imports INFINITE-GAS
+    imports BIN-RUNTIME
 endmodule
 
 module BIN-RUNTIME
-    imports EDSL
+    imports EVM-ABI
 
     syntax Contract
     syntax ByteArray ::= #binRuntime ( Contract ) [alias, klabel(binRuntime), symbol, function, no-evaluators]

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -18,9 +18,6 @@ _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
 def main():
 
-    def _typed_arg_unparser(type_label: str):
-        return lambda x: '#' + type_label + '(' + x + ')'
-
     sys.setrecursionlimit(15000000)
     parser = create_argument_parser()
     args = parser.parse_args()

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -161,6 +161,10 @@ class KEVM(KProve):
         return KApply('#binRuntime', [c])
 
     @staticmethod
+    def hashed_location(compiler: str, base: KInner, offset: KInner) -> KApply:
+        return KApply('#hashedLocation(_,_,_)_HASHED-LOCATIONS_Int_String_Int_IntList', [stringToken(compiler), base, offset])
+
+    @staticmethod
     def abi_calldata(name: str, args: List[KInner]) -> KApply:
         token: KInner = stringToken(name)
         return KApply('#abiCallData(_,_)_EVM-ABI_ByteArray_String_TypedArgs', [token] + args)
@@ -176,6 +180,10 @@ class KEVM(KProve):
     @staticmethod
     def abi_bool(b: KInner) -> KApply:
         return KApply('#bool(_)_EVM-ABI_TypedArg_Int', [b])
+
+    @staticmethod
+    def abi_type(type: str, value: KInner) -> KApply:
+        return KApply('abi_type_' + type, [value])
 
     @staticmethod
     def empty_typedargs() -> KApply:

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -113,6 +113,10 @@ class KEVM(KProve):
         return KApply('pow256_EVM-TYPES_Int', [])
 
     @staticmethod
+    def range_uint8(i: KInner) -> KApply:
+        return KApply('#rangeUInt(_,_)_EVM-TYPES_Bool_Int_Int', [intToken(8), i])
+
+    @staticmethod
     def range_uint160(i: KInner) -> KApply:
         return KApply('#rangeUInt(_,_)_EVM-TYPES_Bool_Int_Int', [intToken(160), i])
 
@@ -121,12 +125,20 @@ class KEVM(KProve):
         return KApply('#rangeUInt(_,_)_EVM-TYPES_Bool_Int_Int', [intToken(256), i])
 
     @staticmethod
+    def range_sint256(i: KInner) -> KApply:
+        return KApply('#rangeSInt(_,_)_EVM-TYPES_Bool_Int_Int', [intToken(256), i])
+
+    @staticmethod
     def range_address(i: KInner) -> KApply:
         return KApply('#rangeAddress(_)_EVM-TYPES_Bool_Int', [i])
 
     @staticmethod
     def range_bool(i: KInner) -> KApply:
         return KApply('#rangeBool(_)_EVM-TYPES_Bool_Int', [i])
+
+    @staticmethod
+    def range_bytes(width: KInner, ba: KInner) -> KApply:
+        return KApply('#rangeBytes(_,_)_EVM-TYPES_Bool_Int_Int', [width, ba])
 
     @staticmethod
     def bool_2_word(cond: KInner) -> KApply:

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -139,7 +139,7 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
     module = KFlatModule(
         module_name,
         [contract_subsort, contract_production] + storage_sentences + function_sentences + [contract_macro] + function_selector_alias_sentences,
-        [KImport('BIN-RUNTIME', True)],
+        [KImport('EDSL', True)],
     )
 
     return module

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -77,7 +77,7 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
 
 
 def gen_claims_for_contract(empty_config: KInner, contract_name: str) -> List[KClaim]:
-    program = KApply('binRuntime', [KApply('contract_' + contract_name)])
+    program = KApply('binRuntime', [KApply(f'contract_{contract_name}')])
     account_cell = KEVM.account_cell(KVariable('ACCT_ID'), KVariable('ACCT_BALANCE'), program, KVariable('ACCT_STORAGE'), KVariable('ACCT_ORIGSTORAGE'), KVariable('ACCT_NONCE'))
     init_subst = {
         'MODE_CELL': KToken('NORMAL', 'Mode'),
@@ -136,11 +136,8 @@ def contract_to_k(contract_json: Dict, contract_name: str, generate_storage: boo
     contract_macro = KRule(KRewrite(KApply('binRuntime', [KApply(contract_klabel)]), KEVM.parse_bytestack(stringToken(bin_runtime))))
 
     module_name = contract_name.upper() + '-BIN-RUNTIME'
-    module = KFlatModule(
-        module_name,
-        [contract_subsort, contract_production] + storage_sentences + function_sentences + [contract_macro] + function_selector_alias_sentences,
-        [KImport('EDSL', True)],
-    )
+    sentences = [contract_subsort, contract_production] + storage_sentences + function_sentences + [contract_macro] + function_selector_alias_sentences
+    module = KFlatModule(module_name, sentences, [KImport('EDSL')])
 
     return module
 

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -346,17 +346,17 @@ def _evm_base_sort(type_label: str):
 
 def _range_predicate(term, type_label: str):
     if type_label == 'address':
-        return KApply('rangeAddress', [term])
+        return KEVM.range_address(term)
     if type_label == 'bool':
-        return KApply('rangeBool', [term])
+        return KEVM.range_bool(term)
     if type_label == 'bytes4':
-        return KApply('rangeBytes', [intToken(4), term])
+        return KEVM.range_bytes(intToken(4), term)
     if type_label in {'bytes32', 'uint256'}:
-        return KApply('rangeUInt', [intToken(256), term])
+        return KEVM.range_uint256(term)
     if type_label == 'int256':
-        return KApply('rangeSInt', [intToken(256), term])
+        return KEVM.range_sint256(term)
     if type_label == 'uint8':
-        return KApply('rangeUInt', [intToken(8), term])
+        return KEVM.range_uint8(term)
     if type_label == 'bytes':
         return None
 

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -1,6 +1,10 @@
+from typing import List
+
 from pyk.kast import (
     KApply,
     KDefinition,
+    KFlatModule,
+    KImport,
     KInner,
     KLabel,
     KNonTerminal,
@@ -17,6 +21,24 @@ from pyk.kastManip import (
     splitConfigFrom,
     substitute,
 )
+from pyk.ktool import KPrint
+from pyk.ktool.kprint import build_symbol_table
+from pyk.utils import hash_str
+
+
+def KPrint_make_unparsing(_self: KPrint, extra_modules: List[KFlatModule] = []) -> KPrint:
+    modules = list(_self.definition.modules) + extra_modules
+    main_module = KFlatModule('UNPARSING', [], [KImport(_m.name) for _m in modules])
+    defn = KDefinition('UNPARSING', [main_module] + modules)
+    kprint = KPrint(str(_self.kompiled_directory))
+    kprint.definition = defn
+    kprint.symbol_table = build_symbol_table(kprint.definition, opinionated=True)
+    kprint.definition_hash = hash_str(kprint.definition)
+    return kprint
+
+
+def KDefinition_module_names(_self: KDefinition) -> List[str]:
+    return [_m.name for _m in _self.modules]
 
 
 def KDefinition_empty_config(definition: KDefinition, sort: KSort) -> KInner:

--- a/tests/gen-spec/dai-bin-runtime.k
+++ b/tests/gen-spec/dai-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module DAI-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= DaiContract 
     

--- a/tests/gen-spec/daijoin-bin-runtime.k
+++ b/tests/gen-spec/daijoin-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module DAIJOIN-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= DaiJoinContract 
     

--- a/tests/gen-spec/foundry/bin-runtime.k.check.expected
+++ b/tests/gen-spec/foundry/bin-runtime.k.check.expected
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module CONTRACT-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= ContractContract 
     
@@ -13,7 +13,7 @@ module CONTRACT-BIN-RUNTIME
 endmodule
 
 module CONTRACTTEST-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= ContractTestContract 
     

--- a/tests/gen-spec/foundry/bin-runtime.k.check.expected
+++ b/tests/gen-spec/foundry/bin-runtime.k.check.expected
@@ -7,7 +7,7 @@ module CONTRACT-BIN-RUNTIME
     
     syntax ContractContract ::= "Contract" [klabel(contract_Contract)]
     
-    rule  ( #binRuntime(Contract) => #parseByteStack ( "0x0x6080604052600080fdfea2646970667358221220febf745518acc26f684d27983160459fa2f213f0d4664cb72e4e8885a5fc079664736f6c634300080f0033" ) )
+    rule  ( #binRuntime ( Contract ) => #parseByteStack ( "0x0x6080604052600080fdfea2646970667358221220febf745518acc26f684d27983160459fa2f213f0d4664cb72e4e8885a5fc079664736f6c634300080f0033" ) )
       
 
 endmodule
@@ -36,16 +36,16 @@ module CONTRACTTEST-BIN-RUNTIME
     rule  ( ContractTest.test_2() => #abiCallData ( "test_2" , .TypedArgs ) )
       
     
-    rule  ( #binRuntime(ContractTest) => #parseByteStack ( "0x0x6080604052348015600f57600080fd5b5060043610603c5760003560e01c80630a9254e4146041578063663bc990146041578063899eb49c146043575b600080fd5b005b6041604b565b565b6049634e487b7160e01b600052600160045260246000fdfea264697066735822122088b9c698d4d8963d9636778228b7adb6c08b645395e41f0e34b84090ec109da464736f6c634300080f0033" ) )
+    rule  ( #binRuntime ( ContractTest ) => #parseByteStack ( "0x0x6080604052348015600f57600080fd5b5060043610603c5760003560e01c80630a9254e4146041578063663bc990146041578063899eb49c146043575b600080fd5b005b6041604b565b565b6049634e487b7160e01b600052600160045260246000fdfea264697066735822122088b9c698d4d8963d9636778228b7adb6c08b645395e41f0e34b84090ec109da464736f6c634300080f0033" ) )
       
     
-    rule  ( selector("setUp") => 177362148 )
+    rule  ( selector ( "setUp" ) => 177362148 )
       
     
-    rule  ( selector("test_1") => 1715194256 )
+    rule  ( selector ( "test_1" ) => 1715194256 )
       
     
-    rule  ( selector("test_2") => 2308879516 )
+    rule  ( selector ( "test_2" ) => 2308879516 )
       
 
 endmodule

--- a/tests/gen-spec/gemjoin-bin-runtime.k
+++ b/tests/gen-spec/gemjoin-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module GEMJOIN-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= GemJoinContract 
     

--- a/tests/gen-spec/jug-bin-runtime.k
+++ b/tests/gen-spec/jug-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module JUG-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= JugContract 
     

--- a/tests/gen-spec/mcd-spec.k.check.expected
+++ b/tests/gen-spec/mcd-spec.k.check.expected
@@ -39,10 +39,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Vat) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Vat ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Vat) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Vat ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -174,7 +174,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Vat)
+                     #binRuntime ( Vat )
                    </code>
                    ...
                  </account>
@@ -230,10 +230,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Jug) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Jug ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Jug) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Jug ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -365,7 +365,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Jug)
+                     #binRuntime ( Jug )
                    </code>
                    ...
                  </account>
@@ -421,10 +421,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(DaiJoin) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( DaiJoin ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(DaiJoin) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( DaiJoin ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -556,7 +556,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(DaiJoin)
+                     #binRuntime ( DaiJoin )
                    </code>
                    ...
                  </account>
@@ -612,10 +612,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Dai) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Dai ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Dai) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Dai ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -747,7 +747,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Dai)
+                     #binRuntime ( Dai )
                    </code>
                    ...
                  </account>
@@ -803,10 +803,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(GemJoin) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( GemJoin ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(GemJoin) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( GemJoin ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -938,7 +938,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(GemJoin)
+                     #binRuntime ( GemJoin )
                    </code>
                    ...
                  </account>
@@ -994,10 +994,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Pot) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Pot ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Pot) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Pot ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -1129,7 +1129,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Pot)
+                     #binRuntime ( Pot )
                    </code>
                    ...
                  </account>
@@ -1185,10 +1185,10 @@ module MCD-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Spotter) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Spotter ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Spotter) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Spotter ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -1320,7 +1320,7 @@ module MCD-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Spotter)
+                     #binRuntime ( Spotter )
                    </code>
                    ...
                  </account>

--- a/tests/gen-spec/pot-bin-runtime.k
+++ b/tests/gen-spec/pot-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module POT-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= PotContract 
     

--- a/tests/gen-spec/spotter-bin-runtime.k
+++ b/tests/gen-spec/spotter-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module SPOTTER-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= SpotterContract 
     

--- a/tests/gen-spec/vat-bin-runtime.k
+++ b/tests/gen-spec/vat-bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module VAT-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports public EDSL
     
     syntax Contract ::= VatContract 
     

--- a/tests/gen-spec/verification.k
+++ b/tests/gen-spec/verification.k
@@ -10,7 +10,6 @@ requires "vat-bin-runtime.k"
 
 module MCD-VERIFICATION
     imports LEMMAS
-    imports INFINITE-GAS
 
     imports DAI-BIN-RUNTIME
     imports DAIJOIN-BIN-RUNTIME

--- a/tests/specs/foundry/bin-runtime.k
+++ b/tests/specs/foundry/bin-runtime.k
@@ -1,7 +1,7 @@
 requires "edsl.md"
 
 module CONTRACT-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports EDSL
     
     syntax Contract ::= ContractContract 
     
@@ -13,7 +13,7 @@ module CONTRACT-BIN-RUNTIME
 endmodule
 
 module CONTRACTTEST-BIN-RUNTIME
-    imports public BIN-RUNTIME
+    imports EDSL
     
     syntax Contract ::= ContractTestContract 
     

--- a/tests/specs/foundry/foundry-spec.k.check.expected
+++ b/tests/specs/foundry/foundry-spec.k.check.expected
@@ -39,10 +39,10 @@ module FOUNDRY-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(ContractTest) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( ContractTest ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(ContractTest) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( ContractTest ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -174,7 +174,7 @@ module FOUNDRY-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(ContractTest)
+                     #binRuntime ( ContractTest )
                    </code>
                    ...
                  </account>
@@ -230,10 +230,10 @@ module FOUNDRY-SPEC
                </touchedAccounts>
                <callState>
                  <program>
-                   ( #binRuntime(Contract) => ?_PROGRAM_CELL_acd26fc5 )
+                   ( #binRuntime ( Contract ) => ?_PROGRAM_CELL_acd26fc5 )
                  </program>
                  <jumpDests>
-                   ( #computeValidJumpDests ( #binRuntime(Contract) ) => ?_JUMPDESTS_CELL_acd26fc5 )
+                   ( #computeValidJumpDests ( #binRuntime ( Contract ) ) => ?_JUMPDESTS_CELL_acd26fc5 )
                  </jumpDests>
                  <id>
                    ( ACCT_ID => ?_ID_CELL_acd26fc5 )
@@ -365,7 +365,7 @@ module FOUNDRY-SPEC
                      ACCT_ID
                    </acctID>
                    <code>
-                     #binRuntime(Contract)
+                     #binRuntime ( Contract )
                    </code>
                    ...
                  </account>


### PR DESCRIPTION
This PR introduces functionality to adjust the symbol table automatically after we have built up an extended definition in `solc-to-k` and `foundry-to-k`.

- `EDSL` becomes the main entry point for the haskell backend, and includes module `BIN-RUNTIME` by default. This reflect the fact that we are never using the Haskell backend without this functionality anyway.
- Some formatting improvements to `solc_to_k.py`.
- Method `KDefinition_module_names` is factored out to get all the module names of a given KDefinition.
- Method `KPrint_make_unparsing` is factored out, which makes the most generic unparsing module possible for a given definition, and even allows extending it with new modules.
- The symbol-table patching we were using after `contract_to_k` and `gen_spec_modules` can now be removed in favor of principled unparser generation using `KPrint_make_unparsing`.
- Many places where we were building terms directly using their KLabels are factored out into static methods of KEVM class for more rigor and easier to read code.
