### PR TITLE
Support Solidity `struct` type in generated specifications

### DIFF
--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -161,8 +161,11 @@ class KEVM(KProve):
         return KApply('#binRuntime', [c])
 
     @staticmethod
-    def hashed_location(compiler: str, base: KInner, offset: KInner) -> KApply:
-        return KApply('#hashedLocation(_,_,_)_HASHED-LOCATIONS_Int_String_Int_IntList', [stringToken(compiler), base, offset])
+    def hashed_location(compiler: str, base: KInner, offset: KInner, member_offset: int = 0) -> KApply:
+        location = KApply('#hashedLocation(_,_,_)_HASHED-LOCATIONS_Int_String_Int_IntList', [stringToken(compiler), base, offset])
+        if member_offset > 0:
+            location = KApply('_+Int_', [location, intToken(member_offset)])
+        return location
 
     @staticmethod
     def abi_calldata(name: str, args: List[KInner]) -> KApply:

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -34,7 +34,7 @@ from pyk.prelude import Sorts, intToken, stringToken
 from pyk.utils import FrozenDict, intersperse
 
 from .kevm import KEVM
-from .utils import abstract_cell_vars, build_claim, check_and_append_sentences
+from .utils import abstract_cell_vars, build_claim
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -211,18 +211,18 @@ class Contract():
     @property
     def method_sentences(self) -> List[KSentence]:
         method_application_production: KSentence = KProduction(KSort('ByteArray'), [KNonTerminal(self.sort), KTerminal('.'), KNonTerminal(self.sort_method)], klabel=self.klabel_method, att=KAtt({'function': ''}))
-        res = [method_application_production]
-        check_and_append_sentences(res, [method.production for method in self.methods])
-        check_and_append_sentences(res, [method.rule(KApply(self.klabel), self.klabel_method, self.name) for method in self.methods])
-        check_and_append_sentences(res, [method.selector_alias_rule for method in self.methods])
+        res: List[KSentence] = [method_application_production]
+        res.extend(method.production for method in self.methods)
+        res.extend(method.rule(KApply(self.klabel), self.klabel_method, self.name) for method in self.methods)
+        res.extend(method.selector_alias_rule for method in self.methods)
         return res if len(res) > 1 else []
 
     @property
     def field_sentences(self) -> List[KSentence]:
         field_access_production: KSentence = KProduction(KSort('Int'), [KNonTerminal(self.sort), KTerminal('.'), KNonTerminal(self.sort_field)], klabel=self.klabel_field, att=KAtt({'macro': ''}))
-        res = [field_access_production]
-        check_and_append_sentences(res, [prod for field in self.fields for prod in field.productions])
-        check_and_append_sentences(res, [rule for field in self.fields for rule in field.rules(KApply(self.klabel), self.klabel_field)])
+        res: List[KSentence] = [field_access_production]
+        res.extend(prod for field in self.fields for prod in field.productions)
+        res.extend(rule for field in self.fields for rule in field.rules(KApply(self.klabel), self.klabel_field))
         return res if len(res) > 1 else []
 
     @property

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -111,18 +111,18 @@ class Contract():
             syntax: List[KProductionItem] = [KTerminal(self.name)]
             curr_type = self.type
             while True:
-                type = self.types[curr_type]
                 if self._direct_placement(curr_type):
                     break
-                elif type['encoding'] == 'mapping':
-                    key_type = type['key']
-                    curr_type = type['value']
+                elif self.types[curr_type]['encoding'] == 'mapping':
+                    key_type = self.types[curr_type]['key']
+                    curr_type = self.types[curr_type]['value']
                     if self._direct_placement(key_type):
                         syntax.extend([KTerminal('['), KNonTerminal(Sorts.INT), KTerminal(']')])
                     else:
                         raise ValueError(f'Unsupported key type for mapping in field {self.sort}: {key_type}')
                 else:
-                    raise ValueError(f'Unsupported type for encoding in field {self.sort}: {self.type}')
+
+                    raise ValueError(f'Unsupported type for encoding in field {self.sort}: {curr_type}')
             return KProduction(self.sort, syntax, klabel=self.klabel)
 
         def rule(self, contract: KInner, application_label: KLabel) -> KRule:

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -73,9 +73,9 @@ class Contract():
 
         def rule(self, contract: KInner, application_label: KLabel, contract_name: str) -> KRule:
             arg_vars = [KVariable(aname) for aname in self.arg_names]
-            prod_label = self.production.klabel
-            assert prod_label is not None
-            lhs = KApply(application_label, [contract, KApply(prod_label, arg_vars)])
+            prod_klabel = self.production.klabel
+            assert prod_klabel is not None
+            lhs = KApply(application_label, [contract, KApply(prod_klabel, arg_vars)])
             args: List[KInner] = [KEVM.abi_type(input_type, KVariable(input_name)) for input_type, input_name in zip(self.arg_types, self.arg_names)]
             rhs = KEVM.abi_calldata(self.name, args)
             opt_conjuncts = [_range_predicate(KVariable(input_name), input_type) for input_name, input_type in zip(self.arg_names, self.arg_types)]
@@ -124,10 +124,9 @@ class Contract():
                 elif self.types[curr_type]['encoding'] == 'mapping':
                     key_type = self.types[curr_type]['key']
                     curr_type = self.types[curr_type]['value']
-                    if self._direct_placement(key_type):
-                        syntax.extend([KTerminal('['), KNonTerminal(Sorts.INT), KTerminal(']')])
-                    else:
+                    if not self._direct_placement(key_type):
                         raise ValueError(f'Unsupported key type for mapping in field {self.sort}: {key_type}')
+                    syntax.extend([KTerminal('['), KNonTerminal(Sorts.INT), KTerminal(']')])
                 else:
                     raise ValueError(f'Unsupported type for encoding in field {self.sort}: {curr_type}')
             return prods

--- a/kevm_pyk/src/kevm_pyk/utils.py
+++ b/kevm_pyk/src/kevm_pyk/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from pyk.cterm import CTerm
 from pyk.kast import (
@@ -11,7 +11,6 @@ from pyk.kast import (
     KLabel,
     KNonTerminal,
     KProduction,
-    KSentence,
     KSort,
     KTerminal,
     KVariable,
@@ -28,12 +27,6 @@ from pyk.kastManip import (
 from pyk.ktool import KPrint
 from pyk.ktool.kprint import build_symbol_table
 from pyk.utils import hash_str
-
-
-def check_and_append_sentences(sents: List[KSentence], _sents: Iterable) -> None:
-    for sent in _sents:
-        assert isinstance(sent, KSentence)
-        sents.append(sent)
 
 
 def build_claim(

--- a/tests/foundry/foundry.k.check.expected
+++ b/tests/foundry/foundry.k.check.expected
@@ -8,7 +8,7 @@ module TOKEN-BIN-RUNTIME
     
     syntax TokenContract ::= "Token" [klabel(contract_Token)]
     
-    rule  ( #binRuntime ( Token ) => #parseByteStack ( "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063a9059cbb14610030575b600080fd5b61004361003e3660046100c9565b610045565b005b610050338383610054565b5050565b6001600160a01b038316600090815260016020526040902054610078908290610117565b6001600160a01b0380851660009081526001602052604080822093909355908416815220546100a890829061012e565b6001600160a01b039092166000908152600160205260409020919091555050565b600080604083850312156100dc57600080fd5b82356001600160a01b03811681146100f357600080fd5b946020939093013593505050565b634e487b7160e01b600052601160045260246000fd5b60008282101561012957610129610101565b500390565b6000821982111561014157610141610101565b50019056fea2646970667358221220df67d0298f49650fad9e5b2dfa3912ecd4de3790831fd79f0c186e563af14e1464736f6c634300080f0033" ) )
+    rule  ( #binRuntime ( Token ) => #parseByteStack ( "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063a9059cbb14610030575b600080fd5b61004361003e3660046100c9565b610045565b005b610050338383610054565b5050565b6001600160a01b038316600090815260016020526040902054610078908290610117565b6001600160a01b0380851660009081526001602052604080822093909355908416815220546100a890829061012e565b6001600160a01b039092166000908152600160205260409020919091555050565b600080604083850312156100dc57600080fd5b82356001600160a01b03811681146100f357600080fd5b946020939093013593505050565b634e487b7160e01b600052601160045260246000fd5b60008282101561012957610129610101565b500390565b6000821982111561014157610141610101565b50019056fea264697066735822122099123615db5c56cfbe9db8e89f9a468439257c4d1afe9c7addba9dc854fdd3ac64736f6c634300080f0033" ) )
       
     
     syntax Int ::= TokenContract "." TokenField [macro(), klabel(field_Token)]
@@ -21,6 +21,14 @@ module TOKEN-BIN-RUNTIME
     
     syntax TokenField ::= "name" [klabel(field_Token_name)]
     
+    syntax TokenField ::= "foos" "[" Int "]" "." "bar" [klabel(field_Token_foos_bar)]
+    
+    syntax TokenField ::= "foos" "[" Int "]" "." "baz" [klabel(field_Token_foos_baz)]
+    
+    syntax TokenField ::= "foos" "[" Int "]" "." "boo" [klabel(field_Token_foos_boo)]
+    
+    syntax TokenField ::= "foos" "[" Int "]" "." "frob" [klabel(field_Token_foos_frob)]
+    
     rule  ( Token . x => #hashedLocation ( "Solidity" , 0 , .IntList ) )
       
     
@@ -31,6 +39,18 @@ module TOKEN-BIN-RUNTIME
       
     
     rule  ( Token . name => #hashedLocation ( "Solidity" , 3 , .IntList ) )
+      
+    
+    rule  ( Token . foos [ V0 ] . bar => #hashedLocation ( "Solidity" , 4 , V0  .IntList ) )
+      
+    
+    rule  ( Token . foos [ V0 ] . baz => ( #hashedLocation ( "Solidity" , 4 , V0  .IntList ) +Int 1 ) )
+      
+    
+    rule  ( Token . foos [ V0 ] . boo => ( #hashedLocation ( "Solidity" , 4 , V0  .IntList ) +Int 2 ) )
+      
+    
+    rule  ( Token . foos [ V0 ] . frob => ( #hashedLocation ( "Solidity" , 4 , V0  .IntList ) +Int 3 ) )
       
     
     syntax ByteArray ::= TokenContract "." TokenMethod [function(), klabel(method_Token)]

--- a/tests/foundry/src/Token.sol
+++ b/tests/foundry/src/Token.sol
@@ -7,6 +7,15 @@ contract Token {
     mapping(address => mapping(address => uint256)) allowances;
     string name;
 
+    struct Foo {
+        uint256 bar;
+        address baz;
+        uint48 boo;
+        uint48 frob;
+    }
+
+    mapping(address => Foo) foos;
+
     function _move(address src, address dst, uint256 amount) internal {
         balances[src] = balances[src] - amount;
         balances[dst] = balances[dst] + amount;


### PR DESCRIPTION
This adds support for the `struct` type in Solidity for the K code generation, and adds a test in the Foundry example of this type.

Notice that we only handle `struct`s that are not complaining except base-types (cannot contain a list in the `struct`, for example). I don't know if Solidity actually has this restriction or not.

- Extend `hashed_location` helper to actually handle what's called a `member_offset`, which is used for recording the offset inside the struct.
- `Contract.Field.{productions,rules}` are extended to return lists of productions/rules, so that we can generate all the productions and rules needed for struct members at the same time.
- An example of a `struct` is added to the Foundry test, and the expected generated output of K is updated.
- Removes the `check_and_append_sentences` with a nicer way of appeasing the type-checker that @tothtamas28 suggested.