### PR TITLE
Implement --pyk option for krun as well

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,9 +24,8 @@ pipeline {
       stages {
         // Must come before build/prove for proper testing
         stage('Check Pyk Version')  { steps { sh 'bash ./kevm_pyk/test-version.sh ${K_VERSION}' } }
-        stage('Setup Pyk')          { steps { sh 'make venv'                                    } }
+        stage('Build')              { steps { sh 'make venv build build-prove RELEASE=true -j4' } }
         stage('Build and Test Pyk') { steps { sh 'make test-kevm-pyk -j2'                       } }
-        stage('Build')              { steps { sh 'make build build-prove RELEASE=true -j2'      } }
         stage('Test') {
           failFast true
           options { timeout(time: 200, unit: 'MINUTES') }

--- a/Makefile
+++ b/Makefile
@@ -478,13 +478,13 @@ tests/foundry/foundry.k.check: tests/foundry/foundry.k
 	$(CHECK) $< $@.expected
 
 tests/foundry/foundry.k.prove: tests/foundry/kompiled/timestamp
-	$(KEVM) prove tests/foundry/foundry.k --pyk --backend haskell --definition tests/foundry/kompiled \
+	$(KEVM) prove tests/foundry/foundry.k --backend haskell --definition tests/foundry/kompiled \
 	    $(TEST_OPTIONS) --spec-module TOKENTEST-BIN-RUNTIME-SPEC
 
 tests/foundry/kompiled/timestamp: tests/foundry/foundry.k
-	$(KOMPILE) $< --pyk --backend haskell --definition tests/foundry/kompiled \
-	    --main-module VERIFICATION --syntax-module VERIFICATION               \
-	    --concrete-rules-file tests/foundry/concrete-rules.txt                \
+	$(KOMPILE) $< --backend haskell --definition tests/foundry/kompiled \
+	    --main-module VERIFICATION --syntax-module VERIFICATION         \
+	    --concrete-rules-file tests/foundry/concrete-rules.txt          \
 	    $(KOMPILE_OPTS)
 
 tests/specs/examples/erc20-spec/haskell/timestamp: tests/specs/examples/erc20-bin-runtime.k
@@ -639,18 +639,20 @@ test-failure: $(failure_tests:=.run-expected)
 
 # kevm_pyk Tests
 
-kevm_pyk_tests :=                                                         \
-                  tests/interactive/vmLogTest/log3.json.gst-to-kore.check \
-                  tests/foundry/kompiled/timestamp                        \
-                  tests/foundry/foundry.k.check                           \
-                  tests/specs/bihu/functional-spec.k.prove                \
-                  tests/specs/examples/empty-bin-runtime.k                \
-                  tests/specs/examples/erc20-bin-runtime.k                \
+kevm_pyk_tests :=                                                                                              \
+                  tests/interactive/vmLogTest/log3.json.gst-to-kore.check                                      \
+                  tests/ethereum-tests/BlockchainTests/GeneralStateTests/VMTests/vmArithmeticTest/add.json.run \
+                  tests/foundry/kompiled/timestamp                                                             \
+                  tests/foundry/foundry.k.check                                                                \
+                  tests/specs/bihu/functional-spec.k.prove                                                     \
+                  tests/specs/examples/empty-bin-runtime.k                                                     \
+                  tests/specs/examples/erc20-bin-runtime.k                                                     \
                   tests/specs/examples/erc721-bin-runtime.k
 
 test-kevm-pyk: KPROVE_OPTS  += --pyk --verbose
 test-kevm-pyk: KOMPILE_OPTS += --pyk --verbose
 test-kevm-pyk: KAST_OPTS += --pyk --verbose
+test-kevm-pyk: TEST_OPTIONS += --pyk --verbose
 test-kevm-pyk: KEVM = $(PYK_ACTIVATE) && kevm
 test-kevm-pyk: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
 test-kevm-pyk: $(kevm_pyk_tests) venv

--- a/Makefile
+++ b/Makefile
@@ -445,6 +445,7 @@ venv-clean:
 	rm -rf ./kevm_pyk/venv-dev
 	rm -rf ./kevm_pyk/venv-prod
 	rm -rf $(KEVM_LIB)/kframework/lib/python3.8
+	rm -rf $(KEVM_LIB)/kframework/local/lib/python3.10
 	rm -rf $(K_SUBMODULE)/pyk/build
 
 venv:

--- a/Makefile
+++ b/Makefile
@@ -658,7 +658,7 @@ kevm_pyk_tests :=                                                               
                   tests/specs/examples/erc20-bin-runtime.k                                                     \
                   tests/specs/examples/erc721-bin-runtime.k
 
-test-kevm-pyk: KEVM_OPTS += --pyk --verbose
+test-kevm-pyk: KEVM_OPTS += --pyk --verbose --profile
 test-kevm-pyk: KEVM = $(PYK_ACTIVATE) && kevm
 test-kevm-pyk: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
 test-kevm-pyk: $(kevm_pyk_tests) venv

--- a/Makefile
+++ b/Makefile
@@ -655,7 +655,7 @@ test-kevm-pyk: KAST_OPTS += --pyk --verbose
 test-kevm-pyk: TEST_OPTIONS += --pyk --verbose
 test-kevm-pyk: KEVM = $(PYK_ACTIVATE) && kevm
 test-kevm-pyk: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
-test-kevm-pyk: $(kevm_pyk_tests) venv | build-llvm
+test-kevm-pyk: $(kevm_pyk_tests) venv
 	wc -l tests/specs/bihu/functional-spec.rule-profile
 
 # Interactive Tests

--- a/Makefile
+++ b/Makefile
@@ -353,7 +353,7 @@ uninstall:
 TEST_CONCRETE_BACKEND := llvm
 TEST_SYMBOLIC_BACKEND := haskell
 
-TEST_OPTIONS :=
+KEVM_OPTIONS :=
 CHECK        := git --no-pager diff --no-index --ignore-all-space -R
 
 KEVM_MODE     := NORMAL
@@ -406,33 +406,33 @@ tests/specs/opcodes/evm-optimizations-spec%: KPROVE_FILE   =  evm-optimizations-
 tests/specs/opcodes/evm-optimizations-spec%: KPROVE_MODULE =  EVM-OPTIMIZATIONS-SPEC-LEMMAS
 
 tests/%.run: tests/%
-	$(KEVM) interpret $< $(TEST_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                               \
+	$(KEVM) interpret $< $(KEVM_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                               \
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)                                      \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                                                        \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
 	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-interactive: tests/%
-	$(KEVM) run $< $(TEST_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                                     \
+	$(KEVM) run $< $(KEVM_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                                     \
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)                                      \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                                                        \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
 	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-expected: tests/% tests/%.expected
-	$(KEVM) run $< $(TEST_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND) \
+	$(KEVM) run $< $(KEVM_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND) \
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)  \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                    \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/$*.expected
 	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.parse: tests/%
-	$(KEVM) kast $< kast $(TEST_OPTIONS) $(KAST_OPTS) --backend $(TEST_CONCRETE_BACKEND) > $@-out
+	$(KEVM) kast $< kast $(KEVM_OPTIONS) $(KAST_OPTS) --backend $(TEST_CONCRETE_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
 	$(KEEP_OUTPUTS) || rm -rf $@-out
 
 tests/interactive/%.json.gst-to-kore.check: tests/ethereum-tests/GeneralStateTests/VMTests/%.json $(KEVM_BIN)/kevm
-	$(PYK_ACTIVATE) && $(KEVM) kast $< kore $(TEST_OPTIONS) $(KAST_OPTS) > tests/interactive/$*.gst-to-kore.out
+	$(PYK_ACTIVATE) && $(KEVM) kast $< kore $(KEVM_OPTIONS) $(KAST_OPTS) > tests/interactive/$*.gst-to-kore.out
 	$(CHECK) tests/interactive/$*.gst-to-kore.out tests/interactive/$*.gst-to-kore.expected
 	$(KEEP_OUTPUTS) || rm -rf tests/interactive/$*.gst-to-kore.out
 
@@ -483,7 +483,7 @@ tests/foundry/foundry.k.check: tests/foundry/foundry.k
 
 tests/foundry/foundry.k.prove: tests/foundry/kompiled/timestamp
 	$(KEVM) prove tests/foundry/foundry.k --backend haskell --definition tests/foundry/kompiled \
-	    $(TEST_OPTIONS) $(KPROVE_OPTS) --spec-module TOKENTEST-BIN-RUNTIME-SPEC
+	    $(KEVM_OPTIONS) $(KPROVE_OPTS) --spec-module TOKENTEST-BIN-RUNTIME-SPEC
 
 tests/foundry/kompiled/timestamp: tests/foundry/foundry.k
 	$(KOMPILE) $< --backend haskell --definition tests/foundry/kompiled \
@@ -508,7 +508,7 @@ tests/specs/examples/empty-bin-runtime.k: tests/specs/examples/Empty.sol $(KEVM_
 
 .SECONDEXPANSION:
 tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/timestamp
-	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $(KPROVE_OPTS)                \
+	$(KEVM) prove $< $(KEVM_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $(KPROVE_OPTS)                \
 	    --definition tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
 tests/specs/%/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
@@ -520,7 +520,7 @@ tests/specs/%/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_F
 	    $(KOMPILE_OPTS)
 
 tests/%.search: tests/%
-	$(KEVM) search $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" $(TEST_OPTIONS) $(KSEARCH_OPTS) --backend $(TEST_SYMBOLIC_BACKEND) > $@-out
+	$(KEVM) search $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" $(KEVM_OPTIONS) $(KSEARCH_OPTS) --backend $(TEST_SYMBOLIC_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
 	$(KEEP_OUTPUTS) || rm -rf $@-out
 
@@ -658,11 +658,7 @@ kevm_pyk_tests :=                                                               
                   tests/specs/examples/erc20-bin-runtime.k                                                     \
                   tests/specs/examples/erc721-bin-runtime.k
 
-test-kevm-pyk: KPROVE_OPTS  += --pyk --verbose
-test-kevm-pyk: KOMPILE_OPTS += --pyk --verbose
-test-kevm-pyk: KAST_OPTS += --pyk --verbose
-test-kevm-pyk: KRUN_OPTS += --pyk --verbose
-test-kevm-pyk: KSEARCH_OPTS += --pyk --verbose
+test-kevm-pyk: KEVM_OPTS += --pyk --verbose
 test-kevm-pyk: KEVM = $(PYK_ACTIVATE) && kevm
 test-kevm-pyk: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
 test-kevm-pyk: $(kevm_pyk_tests) venv

--- a/Makefile
+++ b/Makefile
@@ -655,7 +655,7 @@ test-kevm-pyk: KAST_OPTS += --pyk --verbose
 test-kevm-pyk: TEST_OPTIONS += --pyk --verbose
 test-kevm-pyk: KEVM = $(PYK_ACTIVATE) && kevm
 test-kevm-pyk: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
-test-kevm-pyk: $(kevm_pyk_tests) venv
+test-kevm-pyk: $(kevm_pyk_tests) venv $(KEVM_LIB)/$(llvm_kompiled)
 	wc -l tests/specs/bihu/functional-spec.rule-profile
 
 # Interactive Tests

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ $(KEVM_LIB)/$(haskell_kompiled): $(kevm_includes) $(plugin_includes) $(KEVM_BIN)
 	    $(haskell_main_file) $(HASKELL_KOMPILE_OPTS) \
 	    --main-module $(haskell_main_module)         \
 	    --syntax-module $(haskell_syntax_module)     \
-	    $(KOMPILE_OPTS) $(KEVM_OPTIONS)
+	    $(KOMPILE_OPTS) $(KEVM_OPTS)
 
 # Standalone
 
@@ -253,7 +253,7 @@ $(KEVM_LIB)/$(llvm_kompiled): $(kevm_includes) $(plugin_includes) $(plugin_c_inc
 	    $(llvm_main_file)                     \
 	    --main-module $(llvm_main_module)     \
 	    --syntax-module $(llvm_syntax_module) \
-	    $(KOMPILE_OPTS) $(KEVM_OPTIONS)
+	    $(KOMPILE_OPTS) $(KEVM_OPTS)
 
 # Node
 
@@ -271,7 +271,7 @@ $(KEVM_LIB)/$(node_kore): $(kevm_includes) $(plugin_includes) $(plugin_c_include
 	    $(node_main_file)                     \
 	    --main-module $(node_main_module)     \
 	    --syntax-module $(node_syntax_module) \
-	    $(KOMPILE_OPTS) $(KEVM_OPTIONS)
+	    $(KOMPILE_OPTS) $(KEVM_OPTS)
 
 $(KEVM_LIB)/$(node_kompiled): $(KEVM_LIB)/$(node_kore) $(protobuf_out) $(libff_out)
 	@mkdir -p $(dir $@)
@@ -353,8 +353,7 @@ uninstall:
 TEST_CONCRETE_BACKEND := llvm
 TEST_SYMBOLIC_BACKEND := haskell
 
-KEVM_OPTIONS :=
-CHECK        := git --no-pager diff --no-index --ignore-all-space -R
+CHECK := git --no-pager diff --no-index --ignore-all-space -R
 
 KEVM_MODE     := NORMAL
 KEVM_SCHEDULE := LONDON
@@ -364,6 +363,7 @@ KPROVE_MODULE  = VERIFICATION
 KPROVE_FILE    = verification
 KPROVE_EXT     = k
 
+KEVM_OPTS    ?=
 KPROVE_OPTS  ?=
 KAST_OPTS    ?=
 KRUN_OPTS    ?=
@@ -406,33 +406,33 @@ tests/specs/opcodes/evm-optimizations-spec%: KPROVE_FILE   =  evm-optimizations-
 tests/specs/opcodes/evm-optimizations-spec%: KPROVE_MODULE =  EVM-OPTIMIZATIONS-SPEC-LEMMAS
 
 tests/%.run: tests/%
-	$(KEVM) interpret $< $(KEVM_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                               \
+	$(KEVM) interpret $< $(KEVM_OPTS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                                  \
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)                                      \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                                                        \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
 	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-interactive: tests/%
-	$(KEVM) run $< $(KEVM_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                                     \
+	$(KEVM) run $< $(KEVM_OPTS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                                        \
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)                                      \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                                                        \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
 	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-expected: tests/% tests/%.expected
-	$(KEVM) run $< $(KEVM_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND) \
+	$(KEVM) run $< $(KEVM_OPTS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)    \
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)  \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                    \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/$*.expected
 	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.parse: tests/%
-	$(KEVM) kast $< kast $(KEVM_OPTIONS) $(KAST_OPTS) --backend $(TEST_CONCRETE_BACKEND) > $@-out
+	$(KEVM) kast $< kast $(KEVM_OPTS) $(KAST_OPTS) --backend $(TEST_CONCRETE_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
 	$(KEEP_OUTPUTS) || rm -rf $@-out
 
 tests/interactive/%.json.gst-to-kore.check: tests/ethereum-tests/GeneralStateTests/VMTests/%.json $(KEVM_BIN)/kevm
-	$(PYK_ACTIVATE) && $(KEVM) kast $< kore $(KEVM_OPTIONS) $(KAST_OPTS) > tests/interactive/$*.gst-to-kore.out
+	$(PYK_ACTIVATE) && $(KEVM) kast $< kore $(KEVM_OPTS) $(KAST_OPTS) > tests/interactive/$*.gst-to-kore.out
 	$(CHECK) tests/interactive/$*.gst-to-kore.out tests/interactive/$*.gst-to-kore.expected
 	$(KEEP_OUTPUTS) || rm -rf tests/interactive/$*.gst-to-kore.out
 
@@ -474,8 +474,8 @@ $(foundry_out):
 	cd $(dir $@) && forge test --ffi
 
 tests/foundry/foundry.k: $(foundry_out) $(KEVM_LIB)/$(haskell_kompiled) venv
-	$(KEVM) foundry-to-k $< $(KEVM_OPTIONS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) \
-	     --require lemmas/int-simplification.k --module-import INT-SIMPLIFICATION                      \
+	$(KEVM) foundry-to-k $< $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) \
+	     --require lemmas/int-simplification.k --module-import INT-SIMPLIFICATION                   \
 	     > $@
 
 tests/foundry/foundry.k.check: tests/foundry/foundry.k
@@ -483,32 +483,32 @@ tests/foundry/foundry.k.check: tests/foundry/foundry.k
 
 tests/foundry/foundry.k.prove: tests/foundry/kompiled/timestamp
 	$(KEVM) prove tests/foundry/foundry.k --backend haskell --definition tests/foundry/kompiled \
-	    $(KEVM_OPTIONS) $(KPROVE_OPTS) --spec-module TOKENTEST-BIN-RUNTIME-SPEC
+	    $(KEVM_OPTS) $(KPROVE_OPTS) --spec-module TOKENTEST-BIN-RUNTIME-SPEC
 
 tests/foundry/kompiled/timestamp: tests/foundry/foundry.k
 	$(KOMPILE) $< --backend haskell --definition tests/foundry/kompiled \
 	    --main-module VERIFICATION --syntax-module VERIFICATION         \
 	    --concrete-rules-file tests/foundry/concrete-rules.txt          \
-	    $(KOMPILE_OPTS) $(KEVM_OPTIONS)
+	    $(KOMPILE_OPTS) $(KEVM_OPTS)
 
 tests/specs/examples/erc20-spec/haskell/timestamp: tests/specs/examples/erc20-bin-runtime.k
 tests/specs/examples/erc20-bin-runtime.k: tests/specs/examples/ERC20.sol $(KEVM_LIB)/$(haskell_kompiled) venv
-	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< ERC20 $(KEVM_OPTIONS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module ERC20-VERIFICATION > $@
+	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< ERC20 $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module ERC20-VERIFICATION > $@
 
 tests/specs/examples/erc721-spec/haskell/timestamp: tests/specs/examples/erc721-bin-runtime.k
 tests/specs/examples/erc721-bin-runtime.k: tests/specs/examples/ERC721.sol $(KEVM_LIB)/$(haskell_kompiled) venv
-	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< ERC721 $(KEVM_OPTIONS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module ERC721-VERIFICATION > $@
+	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< ERC721 $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module ERC721-VERIFICATION > $@
 
 tests/specs/examples/storage-spec/haskell/timestamp: tests/specs/examples/storage-bin-runtime.k
 tests/specs/examples/storage-bin-runtime.k: tests/specs/examples/Storage.sol $(KEVM_LIB)/$(haskell_kompiled) venv
-	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< Storage $(KEVM_OPTIONS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module STORAGE-VERIFICATION > $@
+	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< Storage $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module STORAGE-VERIFICATION > $@
 
 tests/specs/examples/empty-bin-runtime.k: tests/specs/examples/Empty.sol $(KEVM_LIB)/$(haskell_kompiled) venv
-	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< Empty $(KEVM_OPTIONS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module EMPTY-VERIFICATION > $@
+	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< Empty $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module EMPTY-VERIFICATION > $@
 
 .SECONDEXPANSION:
 tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/timestamp
-	$(KEVM) prove $< $(KEVM_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $(KPROVE_OPTS)                \
+	$(KEVM) prove $< $(KEVM_OPTS) --backend $(TEST_SYMBOLIC_BACKEND) $(KPROVE_OPTS)                   \
 	    --definition tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
 tests/specs/%/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
@@ -517,10 +517,10 @@ tests/specs/%/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_F
 	    --main-module $(KPROVE_MODULE)                                                                   \
 	    --syntax-module $(KPROVE_MODULE)                                                                 \
 	    --concrete-rules-file tests/specs/$(firstword $(subst /, ,$*))/concrete-rules.txt                \
-	    $(KOMPILE_OPTS) $(KEVM_OPTIONS)
+	    $(KOMPILE_OPTS) $(KEVM_OPTS)
 
 tests/%.search: tests/%
-	$(KEVM) search $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" $(KEVM_OPTIONS) $(KSEARCH_OPTS) --backend $(TEST_SYMBOLIC_BACKEND) > $@-out
+	$(KEVM) search $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" $(KEVM_OPTS) $(KSEARCH_OPTS) --backend $(TEST_SYMBOLIC_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
 	$(KEEP_OUTPUTS) || rm -rf $@-out
 
@@ -658,7 +658,7 @@ kevm_pyk_tests :=                                                               
                   tests/specs/examples/erc20-bin-runtime.k                                                     \
                   tests/specs/examples/erc721-bin-runtime.k
 
-test-kevm-pyk: KEVM_OPTIONS += --pyk --verbose
+test-kevm-pyk: KEVM_OPTS += --pyk --verbose
 test-kevm-pyk: KEVM = $(PYK_ACTIVATE) && kevm
 test-kevm-pyk: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
 test-kevm-pyk: $(kevm_pyk_tests) venv

--- a/Makefile
+++ b/Makefile
@@ -655,7 +655,7 @@ test-kevm-pyk: KAST_OPTS += --pyk --verbose
 test-kevm-pyk: TEST_OPTIONS += --pyk --verbose
 test-kevm-pyk: KEVM = $(PYK_ACTIVATE) && kevm
 test-kevm-pyk: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
-test-kevm-pyk: $(kevm_pyk_tests) venv $(KEVM_LIB)/$(llvm_kompiled)
+test-kevm-pyk: $(kevm_pyk_tests) venv | build-llvm
 	wc -l tests/specs/bihu/functional-spec.rule-profile
 
 # Interactive Tests

--- a/Makefile
+++ b/Makefile
@@ -363,9 +363,11 @@ KEVM_CHAINID  := 1
 KPROVE_MODULE  = VERIFICATION
 KPROVE_FILE    = verification
 KPROVE_EXT     = k
-KPROVE_OPTS   ?=
 
-KAST_OPTS ?=
+KPROVE_OPTS  ?=
+KAST_OPTS    ?=
+KRUN_OPTS    ?=
+KSEARCH_OPTS ?=
 
 KEEP_OUTPUTS := false
 
@@ -404,33 +406,33 @@ tests/specs/opcodes/evm-optimizations-spec%: KPROVE_FILE   =  evm-optimizations-
 tests/specs/opcodes/evm-optimizations-spec%: KPROVE_MODULE =  EVM-OPTIMIZATIONS-SPEC-LEMMAS
 
 tests/%.run: tests/%
-	$(KEVM) interpret $< $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND)                                            \
+	$(KEVM) interpret $< $(TEST_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                               \
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)                                      \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                                                        \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
 	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-interactive: tests/%
-	$(KEVM) run $< $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND)                                                  \
+	$(KEVM) run $< $(TEST_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND)                                     \
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)                                      \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                                                        \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
 	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-expected: tests/% tests/%.expected
-	$(KEVM) run $< $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND)             \
-	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID) \
-	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                   \
+	$(KEVM) run $< $(TEST_OPTIONS) $(KRUN_OPTS) --backend $(TEST_CONCRETE_BACKEND) \
+	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)  \
+	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                    \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/$*.expected
 	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.parse: tests/%
-	$(KEVM) kast $< kast $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND) > $@-out
+	$(KEVM) kast $< kast $(TEST_OPTIONS) $(KAST_OPTS) --backend $(TEST_CONCRETE_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
 	$(KEEP_OUTPUTS) || rm -rf $@-out
 
 tests/interactive/%.json.gst-to-kore.check: tests/ethereum-tests/GeneralStateTests/VMTests/%.json $(KEVM_BIN)/kevm
-	$(PYK_ACTIVATE) && $(KEVM) kast $< kore $(KAST_OPTS) > tests/interactive/$*.gst-to-kore.out
+	$(PYK_ACTIVATE) && $(KEVM) kast $< kore $(TEST_OPTIONS) $(KAST_OPTS) > tests/interactive/$*.gst-to-kore.out
 	$(CHECK) tests/interactive/$*.gst-to-kore.out tests/interactive/$*.gst-to-kore.expected
 	$(KEEP_OUTPUTS) || rm -rf tests/interactive/$*.gst-to-kore.out
 
@@ -481,7 +483,7 @@ tests/foundry/foundry.k.check: tests/foundry/foundry.k
 
 tests/foundry/foundry.k.prove: tests/foundry/kompiled/timestamp
 	$(KEVM) prove tests/foundry/foundry.k --backend haskell --definition tests/foundry/kompiled \
-	    $(TEST_OPTIONS) --spec-module TOKENTEST-BIN-RUNTIME-SPEC
+	    $(TEST_OPTIONS) $(KPROVE_OPTS) --spec-module TOKENTEST-BIN-RUNTIME-SPEC
 
 tests/foundry/kompiled/timestamp: tests/foundry/foundry.k
 	$(KOMPILE) $< --backend haskell --definition tests/foundry/kompiled \
@@ -506,7 +508,7 @@ tests/specs/examples/empty-bin-runtime.k: tests/specs/examples/Empty.sol $(KEVM_
 
 .SECONDEXPANSION:
 tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/timestamp
-	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $(KPROVE_OPTS) \
+	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $(KPROVE_OPTS)                \
 	    --definition tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
 tests/specs/%/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
@@ -518,7 +520,7 @@ tests/specs/%/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_F
 	    $(KOMPILE_OPTS)
 
 tests/%.search: tests/%
-	$(KEVM) search $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) > $@-out
+	$(KEVM) search $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" $(TEST_OPTIONS) $(KSEARCH_OPTS) --backend $(TEST_SYMBOLIC_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
 	$(KEEP_OUTPUTS) || rm -rf $@-out
 
@@ -659,7 +661,8 @@ kevm_pyk_tests :=                                                               
 test-kevm-pyk: KPROVE_OPTS  += --pyk --verbose
 test-kevm-pyk: KOMPILE_OPTS += --pyk --verbose
 test-kevm-pyk: KAST_OPTS += --pyk --verbose
-test-kevm-pyk: TEST_OPTIONS += --pyk --verbose
+test-kevm-pyk: KRUN_OPTS += --pyk --verbose
+test-kevm-pyk: KSEARCH_OPTS += --pyk --verbose
 test-kevm-pyk: KEVM = $(PYK_ACTIVATE) && kevm
 test-kevm-pyk: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
 test-kevm-pyk: $(kevm_pyk_tests) venv

--- a/kevm
+++ b/kevm
@@ -66,10 +66,9 @@ run_kompile() {
         fatal "Command kompile with option --pyk only available for --backend haskell."
     fi
 
-    kompile_opts=( "${run_file}" )
+    kompile_opts=( "${run_file}" --emit-json )
     ${pyk} || kompile_opts+=( --output-definition "${backend_dir}" )
     ${pyk} || kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
-    ${pyk} || kompile_opts+=( --emit-json )
     kompile_opts+=( --hook-namespaces "JSON KRYPTO BLOCKCHAIN" )
 
     if [[ ! -z ${concrete_rules_file} ]]; then

--- a/kevm
+++ b/kevm
@@ -115,7 +115,7 @@ run_kompile() {
 }
 
 run_krun() {
-    local cschedule cmode cchainid parser
+    local cschedule cmode cchainid parser krun_args
 
     check_k_install
 
@@ -133,11 +133,23 @@ run_krun() {
             parser='cat'
             ;;
     esac
-    execute krun --definition "$backend_dir"          \
-         -cSCHEDULE="$cschedule" -pSCHEDULE="$parser" \
-         -cMODE="$cmode"         -pMODE="$parser"     \
-         -cCHAINID="$cchainid"   -pCHAINID="$parser"  \
-         "$run_file" "$@"
+
+    krun_args=(--definition "${backend_dir}" "${run_file}")
+    if ! ${pyk}; then
+        krun_args+=(-cSCHEDULE="${cschedule}" -pSCHEDULE="${parser}")
+        krun_args+=(-cMODE="${cmode}" -pMODE="${parser}")
+        krun_args+=(-cCHAINID="${cchainid}" -pCHAINID="${parser}")
+    else
+        krun_args+=(--schedule ${schedule})
+        krun_args+=(--mode ${mode})
+        krun_args+=(--chainid ${chainid})
+    fi
+
+    if ! ${pyk}; then
+        execute krun "${krun_args[@]}" "$@"
+    else
+        run_kevm_pyk run "${krun_args[@]}" "$@"
+    fi
 }
 
 run_kast() {

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -33,7 +33,7 @@ def main():
         logging.basicConfig(level=logging.DEBUG, format=_LOG_FORMAT)
 
     if args.command == 'compile':
-        res = solc_compile(args.contract_file)
+        res = solc_compile(args.contract_file, profile=args.profile)
         print(json.dumps(res))
 
     elif args.command == 'gst-to-kore':
@@ -63,7 +63,7 @@ def main():
             empty_config = kevm.definition.empty_config(KSort('KevmCell'))
 
             if args.command == 'solc-to-k':
-                solc_json = solc_compile(args.contract_file)
+                solc_json = solc_compile(args.contract_file, profile=args.profile)
                 contract_json = solc_json['contracts'][args.contract_file.name][args.contract_name]
                 contract = Contract(args.contract_name, contract_json, foundry=False)
                 contract_module, contract_claims_module = contract_to_k(contract, empty_config)

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -8,7 +8,7 @@ from typing import Final, List
 
 from pyk.cli_utils import dir_path, file_path
 from pyk.kast import KDefinition, KFlatModule, KImport, KRequire, KSort
-from pyk.ktool import _krun
+from pyk.ktool.krun import _krun
 
 from .gst_to_kore import gst_to_kore
 from .kevm import KEVM

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -170,7 +170,7 @@ def create_argument_parser():
     prove_args.add_argument('--debug-equations', type=list_of(str, delim=','), default=[], help='Comma-separate list of equations to debug.')
     prove_args.add_argument('--bug-report', default=False, action='store_true', help='Generate a haskell-backend bug report for the execution.')
 
-    run_args = command_parser.add_parser('run', help='Run KEVM proof.', parents=[shared_args, evm_chain_args])
+    run_args = command_parser.add_parser('run', help='Run KEVM test/simulation.', parents=[shared_args, evm_chain_args])
     run_args.add_argument('input_file', type=file_path, help='Path to input file.')
     run_args.add_argument('--depth', default=None, type=int, help='Maximum depth to execute to.')
     run_args.add_argument('--term', default=False, action='store_true', help='<input_file> is the entire term to execute.')

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -25,10 +25,12 @@ def main():
     parser = create_argument_parser()
     args = parser.parse_args()
 
-    if args.verbose:
+    if not (args.verbose or args.profile):
+        logging.basicConfig(level=logging.WARNING, format=_LOG_FORMAT)
+    elif args.debug:
         logging.basicConfig(level=logging.DEBUG, format=_LOG_FORMAT)
     else:
-        logging.basicConfig(level=logging.WARNING, format=_LOG_FORMAT)
+        logging.basicConfig(level=logging.INFO, format=_LOG_FORMAT)
 
     if args.command == 'compile':
         res = solc_compile(args.contract_file)
@@ -53,10 +55,11 @@ def main():
                 md_selector=args.md_selector,
                 hook_namespaces=args.hook_namespaces.split(' '),
                 concrete_rules_file=args.concrete_rules_file,
+                profile=args.profile,
             )
 
         else:
-            kevm = KEVM(args.definition_dir)
+            kevm = KEVM(args.definition_dir, profile=args.profile)
             empty_config = kevm.definition.empty_config(KSort('KevmCell'))
 
             if args.command == 'solc-to-k':
@@ -120,7 +123,7 @@ def main():
                     krun_args += ['--no-expand-macros']
                 # TODO: These are inlined into _krun
                 krun_args += ['--output', args.output]
-                krun_result = _krun(kevm.definition_dir, Path(input_file), depth=args.depth, args=krun_args)
+                krun_result = _krun(kevm.definition_dir, Path(input_file), depth=args.depth, args=krun_args, profile=args.profile)
                 print(krun_result.stdout)
                 sys.exit(krun_result.returncode)
 

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -46,6 +46,7 @@ def main():
             kevm = KEVM.kompile(
                 args.definition_dir,
                 args.main_file,
+                emit_json=args.emit_json,
                 includes=args.includes,
                 main_module_name=args.main_module,
                 syntax_module_name=args.syntax_module,
@@ -157,6 +158,8 @@ def create_argument_parser():
     kompile_args.add_argument('--md-selector', type=str, help='Code selector expression to use when reading markdown.')
     kompile_args.add_argument('--hook-namespaces', type=str, help='Hook namespaces. What more can I say?')
     kompile_args.add_argument('--concrete-rules-file', type=str, help='List of rules to only evaluate if arguments are fully concrete.')
+    kompile_args.add_argument('--emit-json', dest='emit_json', default=True, action='store_true', help='Emit JSON definition after compilation.')
+    kompile_args.add_argument('--no-emit-json', dest='emit_json', action='store_false', help='Do not JSON definition after compilation.')
 
     prove_args = command_parser.add_parser('prove', help='Run KEVM proof.', parents=[shared_args])
     prove_args.add_argument('spec_file', type=file_path, help='Path to spec file.')

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -25,12 +25,12 @@ def main():
     parser = create_argument_parser()
     args = parser.parse_args()
 
-    if not (args.verbose or args.profile):
+    if not (args.verbose or args.profile or args.debug):
         logging.basicConfig(level=logging.WARNING, format=_LOG_FORMAT)
-    elif args.debug:
-        logging.basicConfig(level=logging.DEBUG, format=_LOG_FORMAT)
-    else:
+    if args.verbose or args.profile:
         logging.basicConfig(level=logging.INFO, format=_LOG_FORMAT)
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG, format=_LOG_FORMAT)
 
     if args.command == 'compile':
         res = solc_compile(args.contract_file)

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -117,7 +117,9 @@ def main():
                     krun_args += ['--parser', args.parser]
                 if not args.expand_macros:
                     krun_args += ['--no-expand-macros']
-                krun_result = _krun(kevm.definition_dir, Path(input_file), output=args.output, check=False, depth=args.depth, args=krun_args)
+                # TODO: These are inlined into _krun
+                krun_args += ['--output', args.output]
+                krun_result = _krun(kevm.definition_dir, Path(input_file), depth=args.depth, args=krun_args)
                 print(krun_result.stdout)
                 sys.exit(krun_result.returncode)
 

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Final, List, Optional
 from pyk.cli_utils import run_process
 from pyk.kast import KApply, KInner
 from pyk.kastManip import flatten_label, getCell
-from pyk.ktool import KProve, paren
+from pyk.ktool import KProve, KRun, paren
 from pyk.prelude import intToken, stringToken
 
 from .utils import add_include_arg
@@ -19,10 +19,14 @@ _LOGGER: Final = logging.getLogger(__name__)
 # KEVM class
 
 
-class KEVM(KProve):
+class KEVM(KProve, KRun):
 
-    def __init__(self, definition_dir, main_file=None, use_directory=None):
-        super().__init__(definition_dir, main_file=main_file, use_directory=use_directory)
+    def __init__(self, definition_dir: Path, main_file: Optional[Path] = None, use_directory: Optional[Path] = None) -> None:
+        # I'm going for the simplest version here, we can change later if there is an advantage.
+        # https://stackoverflow.com/questions/9575409/calling-parent-class-init-with-multiple-inheritance-whats-the-right-way
+        # Note that they say using `super` supports dependency injection, but I have never liked dependency injection anyway.
+        KProve.__init__(self, definition_dir, use_directory=use_directory, main_file=main_file)
+        KRun.__init__(self, definition_dir, use_directory=use_directory)
         KEVM._patch_symbol_table(self.symbol_table)
 
     @staticmethod

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -8,7 +8,8 @@ from typing import Any, Dict, Final, List, Optional
 from pyk.cli_utils import run_process
 from pyk.kast import KApply, KInner
 from pyk.kastManip import flatten_label, getCell
-from pyk.ktool import KProve, KRun, paren
+from pyk.ktool import KProve, KRun
+from pyk.ktool.kprint import paren
 from pyk.prelude import intToken, stringToken
 
 from .utils import add_include_arg

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -22,12 +22,12 @@ _LOGGER: Final = logging.getLogger(__name__)
 
 class KEVM(KProve, KRun):
 
-    def __init__(self, definition_dir: Path, main_file: Optional[Path] = None, use_directory: Optional[Path] = None) -> None:
+    def __init__(self, definition_dir: Path, main_file: Optional[Path] = None, use_directory: Optional[Path] = None, profile: bool = False) -> None:
         # I'm going for the simplest version here, we can change later if there is an advantage.
         # https://stackoverflow.com/questions/9575409/calling-parent-class-init-with-multiple-inheritance-whats-the-right-way
         # Note that they say using `super` supports dependency injection, but I have never liked dependency injection anyway.
-        KProve.__init__(self, definition_dir, use_directory=use_directory, main_file=main_file)
-        KRun.__init__(self, definition_dir, use_directory=use_directory)
+        KProve.__init__(self, definition_dir, use_directory=use_directory, main_file=main_file, profile=profile)
+        KRun.__init__(self, definition_dir, use_directory=use_directory, profile=profile)
         KEVM._patch_symbol_table(self.symbol_table)
 
     @staticmethod
@@ -41,6 +41,7 @@ class KEVM(KProve, KRun):
         md_selector: Optional[str] = None,
         hook_namespaces: Optional[List[str]] = None,
         concrete_rules_file: Optional[Path] = None,
+        profile: bool = False,
     ) -> 'KEVM':
         command = ['kompile', '--output-definition', str(definition_dir), str(main_file)]
         command += ['--backend', 'haskell']
@@ -56,7 +57,7 @@ class KEVM(KProve, KRun):
                 concrete_rules = ','.join(crf.read().split('\n'))
                 command += ['--concrete-rules', concrete_rules]
         try:
-            run_process(command, logger=_LOGGER)
+            run_process(command, logger=_LOGGER, profile=profile)
         except CalledProcessError as err:
             sys.stderr.write(f'\nkompile stdout:\n{err.stdout}\n')
             sys.stderr.write(f'\nkompile stderr:\n{err.stderr}\n')

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -49,6 +49,8 @@ class KEVM(KProve, KRun):
         command += ['--md-selector', md_selector] if md_selector else []
         command += ['--hook-namespaces', ' '.join(hook_namespaces)] if hook_namespaces else []
         command += add_include_arg(includes)
+        if emit_json:
+            command += ['--emit-json']
         if concrete_rules_file and os.path.exists(concrete_rules_file):
             with open(concrete_rules_file, 'r') as crf:
                 concrete_rules = ','.join(crf.read().split('\n'))

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -34,6 +34,7 @@ class KEVM(KProve, KRun):
     def kompile(
         definition_dir: Path,
         main_file: Path,
+        emit_json: bool = True,
         includes: List[str] = [],
         main_module_name: Optional[str] = None,
         syntax_module_name: Optional[str] = None,
@@ -42,7 +43,7 @@ class KEVM(KProve, KRun):
         concrete_rules_file: Optional[Path] = None,
     ) -> 'KEVM':
         command = ['kompile', '--output-definition', str(definition_dir), str(main_file)]
-        command += ['--emit-json', '--backend', 'haskell']
+        command += ['--backend', 'haskell']
         command += ['--main-module', main_module_name] if main_module_name else []
         command += ['--syntax-module', syntax_module_name] if syntax_module_name else []
         command += ['--md-selector', md_selector] if md_selector else []

--- a/kevm_pyk/src/kevm_pyk/kevm.py
+++ b/kevm_pyk/src/kevm_pyk/kevm.py
@@ -52,7 +52,7 @@ class KEVM(KProve, KRun):
                 concrete_rules = ','.join(crf.read().split('\n'))
                 command += ['--concrete-rules', concrete_rules]
         try:
-            run_process(command, _LOGGER)
+            run_process(command, logger=_LOGGER)
         except CalledProcessError as err:
             sys.stderr.write(f'\nkompile stdout:\n{err.stdout}\n')
             sys.stderr.write(f'\nkompile stderr:\n{err.stderr}\n')

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -207,7 +207,7 @@ class Contract():
         return [self.subsort, self.production, self.macro_bin_runtime] + self.field_sentences + self.method_sentences
 
 
-def solc_compile(contract_file: Path) -> Dict[str, Any]:
+def solc_compile(contract_file: Path, profile: bool = False) -> Dict[str, Any]:
 
     # TODO: add check to kevm:
     # solc version should be >=0.8.0 due to:
@@ -237,7 +237,7 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
     }
 
     try:
-        process_res = run_process(['solc', '--standard-json'], logger=_LOGGER, input=json.dumps(args))
+        process_res = run_process(['solc', '--standard-json'], logger=_LOGGER, input=json.dumps(args), profile=profile)
     except CalledProcessError as err:
         raise RuntimeError('solc error', err.stdout, err.stderr)
 

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -228,7 +228,7 @@ def solc_compile(contract_file: Path) -> Dict[str, Any]:
     }
 
     try:
-        process_res = run_process(['solc', '--standard-json'], _LOGGER, input=json.dumps(args))
+        process_res = run_process(['solc', '--standard-json'], input=json.dumps(args), logger=_LOGGER)
     except CalledProcessError as err:
         raise RuntimeError('solc error', err.stdout, err.stderr)
 


### PR DESCRIPTION
This makes it so that all major functionality of the `kevm` runner script can be diverted through the `kevm_pyk` runner instead.

- Flag `--pyk` is now read by `kevm run` and `kevm interpret` to divert control to the `kevm_pyk` script.
- Rename Makefile variable `TEST_OPTIONS => KEVM_OPTS`, and thread it through the Makefile.
- Add `Makefile` variables `KRUN_OPTS`, `KSEARCH_OPTS` and add in the appropriate places.
- The `kevm_pyk` script supports the needed options to run `make test-conformance KEVM_OPTS=--pyk`.
- Turns on `--emit-json` by default for `kevm_pyk kompile`, but allows turning it off.
- Adds another directory to `make venv-clean` for Ubuntu Jammy.
- Hooks up `kevm_pyk --profile ...` to the appropriate places so that sub-processes are profiled on runs.

Here is some sample output produced running `make test-kevm-pyk` on my machine:

```
8-13 20:42:30,486 pyk.ktool.krun - Running: krun --definition /home/dev/src/evm-semantics/.build/usr/lib/kevm/llvm /tmp/tmp.fysbfVW76y --output json --term --parser cat --no-expand-macros --output kore
8-13 20:42:30,554 pyk.ktool.krun - Timing [0.068]: krun --definition /home/dev/src/evm-semantics/.build/usr/lib/kevm/llvm /tmp/tmp.fysbfVW76y --output json --term --parser cat --no-expand-macros --output kore
8-13 20:42:30,554 pyk.ktool.krun - Completed: krun --definition /home/dev/src/evm-semantics/.build/usr/lib/kevm/llvm /tmp/tmp.fysbfVW76y --output json --term --parser cat --no-expand-macros --output kore
1.310s 0m0.092s python3 -m kevm_pyk run --definition /home/dev/src/evm-semantics/.build/usr/lib/kevm/llvm /tmp/tmp.fysbfVW76y --schedule LONDON --mode NORMAL --chainid 1 --term --parser cat --no-expand-macros --output kore --profile --definition /home/dev/src/evm-semantics/
```

So we can see here that the actual call to `krun ...` bash script takes 0.068s, and the overall call to `kevm_pyk run ...` takes 1.310s. So we introduce about 1.3s of overhead by running through pyk. This is lower than the original 4s because of this: https://github.com/runtimeverification/k/pull/2800.