### PR TITLE
Small cleanups on kevm_pyk CLI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,10 @@ pipeline {
         stage('Check Pyk Version')    { steps { sh 'bash ./kevm_pyk/test-version.sh ${K_VERSION}' } }
         stage('Check Pyk Code Style') { steps { sh 'make kevm-pyk'                                } }
         stage('Build')                { steps { sh 'make venv build build-prove RELEASE=true -j4' } }
-        stage('Build and Test Pyk')   { steps { sh 'make test-kevm-pyk -j2'                       } }
+        stage('Build and Test Pyk') {
+          options { timeout(time: 60, unit: 'MINUTES') }
+          steps { sh 'make test-kevm-pyk -j2' }
+        }
         stage('Test') {
           failFast true
           options { timeout(time: 200, unit: 'MINUTES') }

--- a/Makefile
+++ b/Makefile
@@ -502,9 +502,9 @@ tests/foundry/kompiled/timestamp: tests/foundry/foundry.k
 	    --concrete-rules-file tests/foundry/concrete-rules.txt          \
 	    $(KOMPILE_OPTS) $(KEVM_OPTS)
 
-tests/specs/%-bin-runtime.k: KEVM_OPTS += --pyk --verbose --profile
-tests/specs/%-bin-runtime.k: KEVM = $(PYK_ACTIVATE) && kevm
-tests/specs/%-bin-runtime.k: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
+tests/specs/examples/%-bin-runtime.k: KEVM_OPTS += --pyk --verbose --profile
+tests/specs/examples/%-bin-runtime.k: KEVM = $(PYK_ACTIVATE) && kevm
+tests/specs/examples/%-bin-runtime.k: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
 
 tests/specs/examples/erc20-spec/haskell/timestamp: tests/specs/examples/erc20-bin-runtime.k
 tests/specs/examples/erc20-bin-runtime.k: tests/specs/examples/ERC20.sol $(KEVM_LIB)/$(haskell_kompiled) venv

--- a/Makefile
+++ b/Makefile
@@ -486,6 +486,7 @@ tests/foundry/foundry.k: $(foundry_out) $(KEVM_LIB)/$(haskell_kompiled) venv
 	$(KEVM) foundry-to-k $< $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) \
 	     --require lemmas/int-simplification.k --module-import INT-SIMPLIFICATION                   \
 	     --exclude-tests tests/foundry/exclude                                                      \
+	     --main-module VERIFICATION                                                                 \
 	     > $@
 
 tests/foundry/foundry.k.check: tests/foundry/foundry.k
@@ -501,20 +502,24 @@ tests/foundry/kompiled/timestamp: tests/foundry/foundry.k
 	    --concrete-rules-file tests/foundry/concrete-rules.txt          \
 	    $(KOMPILE_OPTS) $(KEVM_OPTS)
 
+tests/specs/%-bin-runtime.k: KEVM_OPTS += --pyk --verbose --profile
+tests/specs/%-bin-runtime.k: KEVM = $(PYK_ACTIVATE) && kevm
+tests/specs/%-bin-runtime.k: KOMPILE = $(PYK_ACTIVATE) && kevm kompile
+
 tests/specs/examples/erc20-spec/haskell/timestamp: tests/specs/examples/erc20-bin-runtime.k
 tests/specs/examples/erc20-bin-runtime.k: tests/specs/examples/ERC20.sol $(KEVM_LIB)/$(haskell_kompiled) venv
-	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< ERC20 $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module ERC20-VERIFICATION > $@
+	$(KEVM) solc-to-k $< ERC20 $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module ERC20-VERIFICATION > $@
 
 tests/specs/examples/erc721-spec/haskell/timestamp: tests/specs/examples/erc721-bin-runtime.k
 tests/specs/examples/erc721-bin-runtime.k: tests/specs/examples/ERC721.sol $(KEVM_LIB)/$(haskell_kompiled) venv
-	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< ERC721 $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module ERC721-VERIFICATION > $@
+	$(KEVM) solc-to-k $< ERC721 $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module ERC721-VERIFICATION > $@
 
 tests/specs/examples/storage-spec/haskell/timestamp: tests/specs/examples/storage-bin-runtime.k
 tests/specs/examples/storage-bin-runtime.k: tests/specs/examples/Storage.sol $(KEVM_LIB)/$(haskell_kompiled) venv
-	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< Storage $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module STORAGE-VERIFICATION > $@
+	$(KEVM) solc-to-k $< Storage $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module STORAGE-VERIFICATION > $@
 
 tests/specs/examples/empty-bin-runtime.k: tests/specs/examples/Empty.sol $(KEVM_LIB)/$(haskell_kompiled) venv
-	$(PYK_ACTIVATE) && $(KEVM) solc-to-k $< Empty $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module EMPTY-VERIFICATION > $@
+	$(KEVM) solc-to-k $< Empty $(KEVM_OPTS) --verbose --definition $(KEVM_LIB)/$(haskell_kompiled_dir) --main-module EMPTY-VERIFICATION > $@
 
 .SECONDEXPANSION:
 tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/timestamp

--- a/kevm
+++ b/kevm
@@ -50,11 +50,16 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 # -------
 
 run_kevm_pyk() {
-    local pyk_args
-    pyk_args=(--definition "${backend_dir}")
-    pyk_args+=(-I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework")
+    local pyk_command pyk_args
+    pyk_command="$1" ; shift
+    case "${pyk_command}" in
+        kompile|run|prove|solc-to-k|foundry-to-k)
+            pyk_args=(--definition "${backend_dir}")
+            pyk_args+=(-I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework")
+            ;;
+    esac
     ! ${verbose} || pyk_args+=(--verbose)
-    execute python3 -m kevm_pyk "$@" "${pyk_args[@]}"
+    execute python3 -m kevm_pyk "${pyk_command}" "$@" "${pyk_args[@]}"
 }
 
 # User Commands

--- a/kevm
+++ b/kevm
@@ -135,6 +135,7 @@ run_krun() {
 
     krun_args=(--definition "${backend_dir}" "${run_file}")
     if ! ${pyk}; then
+        ! ${debugger} || krun_args+=(--debugger)
         krun_args+=(-cSCHEDULE="${cschedule}" -pSCHEDULE="${parser}")
         krun_args+=(-cMODE="${cmode}" -pMODE="${parser}")
         krun_args+=(-cCHAINID="${cchainid}" -pCHAINID="${parser}")
@@ -257,7 +258,6 @@ run_interpret() {
     run_kast kore > ${kast}
     run_file="${kast}"
     krun_args=(--term --parser cat --no-expand-macros --output kore)
-    ! ${debugger} || krun_args+=(--debugger)
     if [[ ${backend} == haskell ]]; then
         KORE_EXEC_OPTS="${KORE_EXEC_OPTS:-} --smt none"
         haskell_backend_command+=(--smt none)

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -76,8 +76,8 @@ def exec_solc_to_k(
     profile: bool,
     contract_file: Path,
     contract_name: str,
-    main_module: str,
-    spec_module: str,
+    main_module: Optional[str],
+    spec_module: Optional[str],
     requires: List[str],
     imports: List[str],
     exclude_tests: Optional[Path],
@@ -95,8 +95,8 @@ def exec_solc_to_k(
     contract_module, contract_claims_module = contract_to_k(contract, empty_config, foundry=False, exclude_tests=_exclude_tests)
     modules = [contract_module]
     claims_modules = [contract_claims_module] if contract_claims_module else []
-    _main_module = KFlatModule(main_module, [], [KImport(mname) for mname in [_m.name for _m in modules] + imports])
-    _spec_module = KFlatModule(spec_module, [], [KImport(mname) for mname in [_m.name for _m in claims_modules]])
+    _main_module = KFlatModule(main_module if main_module else 'MAIN', [], [KImport(mname) for mname in [_m.name for _m in modules] + imports])
+    _spec_module = KFlatModule(spec_module if spec_module else 'SPEC', [], [KImport(mname) for mname in [_m.name for _m in claims_modules]])
     modules.append(_main_module)
     modules.append(_spec_module)
     bin_runtime_definition = KDefinition(_main_module.name, modules + claims_modules, requires=[KRequire(req) for req in ['edsl.md'] + requires])
@@ -109,8 +109,8 @@ def exec_foundry_to_k(
     definition_dir: Path,
     profile: bool,
     out: Path,
-    main_module: str,
-    spec_module: str,
+    main_module: Optional[str],
+    spec_module: Optional[str],
     requires: List[str],
     imports: List[str],
     exclude_tests: Optional[Path],
@@ -140,8 +140,8 @@ def exec_foundry_to_k(
             modules.append(module)
             if claims_module:
                 claims_modules.append(claims_module)
-    _main_module = KFlatModule(main_module, [], [KImport(mname) for mname in [_m.name for _m in modules] + imports])
-    _spec_module = KFlatModule(spec_module, [], [KImport(mname) for mname in [_m.name for _m in claims_modules]])
+    _main_module = KFlatModule(main_module if main_module else 'MAIN', [], [KImport(mname) for mname in [_m.name for _m in modules] + imports])
+    _spec_module = KFlatModule(spec_module if spec_module else 'SPEC', [], [KImport(mname) for mname in [_m.name for _m in claims_modules]])
     modules.append(_main_module)
     modules.append(_spec_module)
     bin_runtime_definition = KDefinition(_main_module.name, modules + claims_modules, requires=[KRequire(req) for req in ['edsl.md', 'lemmas/int-simplification.k', 'lemmas/lemmas.k'] + requires])
@@ -217,9 +217,9 @@ def _create_argument_parser() -> ArgumentParser:
     k_args = ArgumentParser(add_help=False)
     k_args.add_argument('--depth', default=None, type=int, help='Maximum depth to execute to.')
     k_args.add_argument('-I', type=str, dest='includes', default=[], action='append', help='Directories to lookup K definitions in.')
-    k_args.add_argument('--main-module', default='MAIN', type=str, help='Name of the main module.')
-    k_args.add_argument('--syntax-module', default='SYNTAX', type=str, help='Name of the syntax module.')
-    k_args.add_argument('--spec-module', default='SPEC', type=str, help='Name of the spec module.')
+    k_args.add_argument('--main-module', default=None, type=str, help='Name of the main module.')
+    k_args.add_argument('--syntax-module', default=None, type=str, help='Name of the syntax module.')
+    k_args.add_argument('--spec-module', default=None, type=str, help='Name of the spec module.')
     k_args.add_argument('--definition', type=str, dest='definition_dir', help='Path to definition to use.')
 
     evm_chain_args = ArgumentParser(add_help=False)

--- a/kevm_pyk/src/kevm_pyk/__main__.py
+++ b/kevm_pyk/src/kevm_pyk/__main__.py
@@ -213,7 +213,6 @@ def _create_argument_parser() -> ArgumentParser:
     shared_args.add_argument('--verbose', '-v', default=False, action='store_true', help='Verbose output.')
     shared_args.add_argument('--debug', default=False, action='store_true', help='Debug output.')
     shared_args.add_argument('--profile', default=False, action='store_true', help='Coarse process-level profiling.')
-    shared_args.add_argument('--definition', type=str, dest='definition_dir', help='Path to definition to use.')
 
     k_args = ArgumentParser(add_help=False)
     k_args.add_argument('--depth', default=None, type=int, help='Maximum depth to execute to.')
@@ -221,6 +220,7 @@ def _create_argument_parser() -> ArgumentParser:
     k_args.add_argument('--main-module', default='MAIN', type=str, help='Name of the main module.')
     k_args.add_argument('--syntax-module', default='SYNTAX', type=str, help='Name of the syntax module.')
     k_args.add_argument('--spec-module', default='SPEC', type=str, help='Name of the spec module.')
+    k_args.add_argument('--definition', type=str, dest='definition_dir', help='Path to definition to use.')
 
     evm_chain_args = ArgumentParser(add_help=False)
     evm_chain_args.add_argument('--schedule', type=str, default='LONDON', help='KEVM Schedule to use for execution. One of [DEFAULT|FRONTIER|HOMESTEAD|TANGERINE_WHISTLE|SPURIOUS_DRAGON|BYZANTIUM|CONSTANTINOPLE|PETERSBURG|ISTANBUL|BERLIN|LONDON].')

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -257,18 +257,22 @@ def solc_compile(contract_file: Path, profile: bool = False) -> Dict[str, Any]:
 
 def gen_claims_for_contract(empty_config: KInner, contract_name: str, calldata_cells: List[Tuple[str, KInner, KInner]] = None) -> List[KClaim]:
     program = KEVM.bin_runtime(KApply(f'contract_{contract_name}'))
-    account_cell = KEVM.account_cell(Foundry.address_TEST_CONTRACT(),
-                                     intToken(0),
-                                     program,
-                                     KVariable('ACCT_STORAGE'),
-                                     KVariable('ACCT_ORIGSTORAGE'),
-                                     intToken(0))
-    post_account_cell = KEVM.account_cell(Foundry.address_TEST_CONTRACT(),
-                                          KVariable('ACCT_BALANCE'),
-                                          program,
-                                          KVariable('ACCT_STORAGE_FINAL'),
-                                          KVariable('ACCT_ORIGSTORAGE'),
-                                          KVariable('ACCT_NONCE'))
+    account_cell = KEVM.account_cell(
+        Foundry.address_TEST_CONTRACT(),
+        intToken(0),
+        program,
+        KVariable('ACCT_STORAGE'),
+        KVariable('ACCT_ORIGSTORAGE'),
+        intToken(0),
+    )
+    post_account_cell = KEVM.account_cell(
+        Foundry.address_TEST_CONTRACT(),
+        KVariable('ACCT_BALANCE'),
+        program,
+        KVariable('ACCT_STORAGE_FINAL'),
+        KVariable('ACCT_ORIGSTORAGE'),
+        KVariable('ACCT_NONCE'),
+    )
     init_subst = {
         'MODE_CELL': KToken('NORMAL', 'Mode'),
         'SCHEDULE_CELL': KApply('LONDON_EVM'),

--- a/kevm_pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm_pyk/src/kevm_pyk/solc_to_k.py
@@ -309,9 +309,9 @@ def gen_claims_for_contract(empty_config: KInner, contract_name: str, calldata_c
     }
     init_term = substitute(empty_config, init_subst)
     if calldata_cells:
-        init_terms = [(tn, substitute(init_term, {'CALLDATA_CELL': cd, 'CALLVALUE_CELL': cv})) for tn, cd, cv in calldata_cells]
+        init_terms = [(tn.replace('_', '-'), substitute(init_term, {'CALLDATA_CELL': cd, 'CALLVALUE_CELL': cv})) for tn, cd, cv in calldata_cells]
     else:
-        init_terms = [(contract_name, init_term)]
+        init_terms = [(contract_name.replace('_', '-'), init_term)]
     final_cterm = CTerm(abstract_cell_vars(substitute(empty_config, final_subst), [KVariable('STATUSCODE_FINAL')]))
     key_dst = KEVM.loc(KToken('FoundryCheat . Failed', 'ContractAccess'))
     dst_failed_prev = KEVM.lookup(KVariable('CHEATCODE_STORAGE'), key_dst)

--- a/tests/foundry/foundry.k.check.expected
+++ b/tests/foundry/foundry.k.check.expected
@@ -2709,7 +2709,7 @@ module DEALTEST-BIN-RUNTIME-SPEC
     imports public VERIFICATION
     imports public DEALTEST-BIN-RUNTIME
     
-    claim [dealtest-0]: <kevm>
+    claim [testDeal]: <kevm>
            <k>
              ( #execute => #halt )
              ~> _CONTINUATION
@@ -2969,7 +2969,7 @@ module DEALTEST-BIN-RUNTIME-SPEC
          </kevm>
       requires #lookup ( CHEATCODE_STORAGE , #loc ( FoundryCheat . Failed ) ) ==Int 0
        ensures foundry_success  ( ?STATUSCODE_FINAL , #lookup ( ?CHEATCODE_STORAGE_FINAL , #loc ( FoundryCheat . Failed ) ) )
-      [label(dealtest-0)]
+      [label(testDeal)]
 
 endmodule
 
@@ -2977,7 +2977,7 @@ module ASSERTTEST-BIN-RUNTIME-SPEC
     imports public VERIFICATION
     imports public ASSERTTEST-BIN-RUNTIME
     
-    claim [asserttest-0]: <kevm>
+    claim [test-assert-true]: <kevm>
            <k>
              ( #execute => #halt )
              ~> _CONTINUATION
@@ -3237,7 +3237,7 @@ module ASSERTTEST-BIN-RUNTIME-SPEC
          </kevm>
       requires #lookup ( CHEATCODE_STORAGE , #loc ( FoundryCheat . Failed ) ) ==Int 0
        ensures foundry_success  ( ?STATUSCODE_FINAL , #lookup ( ?CHEATCODE_STORAGE_FINAL , #loc ( FoundryCheat . Failed ) ) )
-      [label(asserttest-0)]
+      [label(test-assert-true)]
 
 endmodule
 

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -2,7 +2,7 @@ requires "evm.md"
 requires "edsl.md"
 requires "int-simplification.k"
 
-module LEMMAS
+module LEMMAS [symbolic]
     imports INT-SIMPLIFICATION
     imports LEMMAS-JAVA
     imports LEMMAS-HASKELL


### PR DESCRIPTION
This PR is several more small cleanups:

- Pull out `k_args` argument parser, re-arrange arguments to group them better.
- Make sure that `--debugger` argument is handled correctly whether you call `kevm interpret ...` or `kevm run ...`.
- Handle the `--depth` argument for both `kevm_pyk [run|prove]`.
- Small formatting for `gen_claims_for_contract`.
- Better claim identifiers related to their original test names.
- Make sure that `LEMMAS` module does not get sent to LLVM backend.
- Set's a CI timeout for test-kevm-pyk stage.