### PR TITLE
Less restrictive rules for Foundry cheatcodes.

### DIFF
--- a/foundry.md
+++ b/foundry.md
@@ -109,7 +109,7 @@ This rule then takes a `bool` condition using `#range(LM, ARGSTART +Int 4, 32)` 
 ```k
 
     rule [call.assume]:
-         <k> CALL _ CHEAT_ADDR 0 ARGSTART _ARGWIDTH 0 0 => #assume(#range(LM, ARGSTART +Int 4, 32) ==K #bufStrict(32, 1)) ~> 1 ~> #push ... </k>
+         <k> CALL _ CHEAT_ADDR _VALUE ARGSTART _ARGWIDTH _RETSTART _RETWIDTH => #assume(#range(LM, ARGSTART +Int 4, 32) ==K #bufStrict(32, 1)) ~> 1 ~> #push ... </k>
          <output> _ => .ByteArray </output>
          <localMem> LM </localMem>
       requires CHEAT_ADDR ==Int #address(FoundryCheat)
@@ -128,7 +128,7 @@ This rule then takes the account using `#asWord(#range(LM, ARGSTART +Int 4, 32)`
 
 ```k
     rule [call.deal]:
-         <k> CALL _ CHEAT_ADDR 0 ARGSTART _ARGWIDTH 0 0 => #setBalance(#asWord(#range(LM, ARGSTART +Int 4, 32)), #asWord(#range(LM, ARGSTART +Int 36, 32))) ~> 1 ~> #push ... </k>
+         <k> CALL _ CHEAT_ADDR _VALUE ARGSTART _ARGWIDTH _RETSTART _RETWIDTH => #setBalance(#asWord(#range(LM, ARGSTART +Int 4, 32)), #asWord(#range(LM, ARGSTART +Int 36, 32))) ~> 1 ~> #push ... </k>
          <output> _ => .ByteArray </output>
          <localMem> LM </localMem>
       requires CHEAT_ADDR ==Int #address(FoundryCheat)
@@ -157,7 +157,7 @@ The values are forwarded to the `#setCode` marker which updates the account acco
 
 ```k
     rule [call.etch]:
-         <k> CALL _ CHEAT_ADDR 0 ARGSTART ARGWIDTH 0 0
+         <k> CALL _ CHEAT_ADDR _VALUE ARGSTART ARGWIDTH _RETSTART _RETWIDTH
           => #setCode(#asWord(#range(LM, ARGSTART +Int 4, 32)), #range(LM, ARGSTART +Int 36, ARGWIDTH -Int 36))
           ~> 1 ~> #push
          ...
@@ -189,7 +189,7 @@ This rule then takes the uint256 value using `#asWord(#range(LM, ARGSTART +Int 4
 
 ```k
     rule [call.warp]:
-         <k> CALL _ CHEAT_ADDR 0 ARGSTART _ARGWIDTH 0 0 => 1 ~> #push ... </k>
+         <k> CALL _ CHEAT_ADDR _VALUE ARGSTART _ARGWIDTH _RETSTART _RETWIDTH => 1 ~> #push ... </k>
          <output> _ => .ByteArray </output>
          <localMem> LM </localMem>
          <timestamp> _ => #asWord(#range(LM, ARGSTART +Int 4, 32)) </timestamp>
@@ -209,7 +209,7 @@ This rule then takes the `uint256` value using `#asWord(#range(LM, ARGSTART +Int
 
 ```k
     rule [call.roll]:
-         <k> CALL _ CHEAT_ADDR 0 ARGSTART _ARGWIDTH 0 0 => 1 ~> #push ... </k>
+         <k> CALL _ CHEAT_ADDR _VALUE ARGSTART _ARGWIDTH _RETSTART _RETWIDTH => 1 ~> #push ... </k>
          <output> _ => .ByteArray </output>
          <localMem> LM </localMem>
          <number> _ => #asWord(#range(LM, ARGSTART +Int 4, 32)) </number>
@@ -218,7 +218,7 @@ This rule then takes the `uint256` value using `#asWord(#range(LM, ARGSTART +Int
       [priority(40)]
 ```
 
-#### `fee` - Sets the block number.
+#### `fee` - Sets the block base fee.
 
 ```
 function fee(uint256) external;
@@ -229,7 +229,7 @@ This rule then takes the `uint256` value using `#asWord(#range(LM, ARGSTART +Int
 
 ```k
     rule [call.fee]:
-         <k> CALL _ CHEAT_ADDR 0 ARGSTART _ARGWIDTH 0 0 => 1 ~> #push ... </k>
+         <k> CALL _ CHEAT_ADDR _VALUE ARGSTART _ARGWIDTH _RETSTART _RETWIDTH => 1 ~> #push ... </k>
          <output> _ => .ByteArray </output>
          <localMem> LM </localMem>
          <baseFee> _ => #asWord(#range(LM, ARGSTART +Int 4, 32)) </baseFee>
@@ -238,7 +238,7 @@ This rule then takes the `uint256` value using `#asWord(#range(LM, ARGSTART +Int
       [priority(40)]
 ```
 
-#### `chainId` - Sets the block number.
+#### `chainId` - Sets the chain ID.
 
 ```
 function chainId(uint256) external;
@@ -249,7 +249,7 @@ This rule then takes the `uint256` value using `#asWord(#range(LM, ARGSTART +Int
 
 ```k
     rule [call.chainId]:
-         <k> CALL _ CHEAT_ADDR 0 ARGSTART _ARGWIDTH 0 0 => 1 ~> #push ... </k>
+         <k> CALL _ CHEAT_ADDR _VALUE ARGSTART _ARGWIDTH _RETSTART _RETWIDTH => 1 ~> #push ... </k>
          <output> _ => .ByteArray </output>
          <localMem> LM </localMem>
          <chainID> _ => #asWord(#range(LM, ARGSTART +Int 4, 32)) </chainID>
@@ -258,7 +258,7 @@ This rule then takes the `uint256` value using `#asWord(#range(LM, ARGSTART +Int
       [priority(40)]
 ```
 
-#### `coinbase` - Sets the block number.
+#### `coinbase` - Sets the block coinbase.
 
 ```
 function coinbase(address) external;
@@ -269,7 +269,7 @@ This rule then takes the `uint256` value using `#asWord(#range(LM, ARGSTART +Int
 
 ```k
     rule [call.coinbase]:
-         <k> CALL _ CHEAT_ADDR 0 ARGSTART _ARGWIDTH 0 0 => 1 ~> #push ... </k>
+         <k> CALL _ CHEAT_ADDR _VALUE ARGSTART _ARGWIDTH _RETSTART _RETWIDTH => 1 ~> #push ... </k>
          <output> _ => .ByteArray </output>
          <localMem> LM </localMem>
          <coinbase> _ => #asWord(#range(LM, ARGSTART +Int 4, 32)) </coinbase>
@@ -290,7 +290,7 @@ However, there is no change on the state and therefore this rule just skips the 
 
 ```k
     rule [call.label]:
-         <k> CALL _ CHEAT_ADDR 0 ARGSTART _ARGWIDTH 0 0 => 1 ~> #push ... </k>
+         <k> CALL _ CHEAT_ADDR _VALUE ARGSTART _ARGWIDTH _RETSTART _RETWIDTH => 1 ~> #push ... </k>
          <output> _ => .ByteArray </output>
          <localMem> LM </localMem>
       requires CHEAT_ADDR ==Int #address(FoundryCheat)


### PR DESCRIPTION
Fixes https://github.com/runtimeverification/foundry-tests/issues/23

Previously, cheatcodes where matched against the following CALL instruction:

  CALL _ CHEAT_ADDR 0 ARGSTART _ARGWIDTH 0 0

In this commit, this is changed as follows:

  CALL _ CHEAT_ADDR _VALUE ARGSTART _ARGWIDTH _RETSTART _RETWIDTH

In particular:
1. The memory region that contains the return value may now be arbitrary (_RETSTART and _RETWIDTH)
2. An arbitrary amount of ether may be sent when calling the cheatcode (_VALUE)

Because RETSTART and RETWIDTH were initially required to be zero, the K rules where actually never applied. This is because the bytecode emitted by the Solidity compiler always sets RETSTART to a non-zero value, even for functions that do not return any value.

Allowing arbitrary ether to be sent along with cheatcodes ensures we are consistent with Foundry. Note that the ether is not actually transferred but simply ignored. This, too, is consistent with Foundry.