### PR TITLE
Print output of failing proofs

### DIFF
--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -348,7 +348,9 @@ def exec_foundry_prove(
     _failed_claim_ids = [cid for cid, _ in failed_claims]
 
     if _failed_claim_ids:
-        print(f'Failed to prove KCFGs: {_failed_claim_ids}\n')
+        #print(f'Failed to prove KCFGs: {_failed_claim_ids}\n')
+        for (_,result) in failed_claims:
+            print(kevm.pretty_print(result) + '\n')
 
     sys.exit(len(_failed_claim_ids))
 

--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -348,7 +348,6 @@ def exec_foundry_prove(
     _failed_claim_ids = [cid for cid, _ in failed_claims]
 
     if _failed_claim_ids:
-        #print(f'Failed to prove KCFGs: {_failed_claim_ids}\n')
         for (cid,result) in failed_claims:
             print(f'Failed to prove KCFG: {cid}\n')
             print(kevm.pretty_print(result) + '\n')

--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -349,7 +349,8 @@ def exec_foundry_prove(
 
     if _failed_claim_ids:
         #print(f'Failed to prove KCFGs: {_failed_claim_ids}\n')
-        for (_,result) in failed_claims:
+        for (cid,result) in failed_claims:
+            print(f'Failed to prove KCFG: {cid}\n')
             print(kevm.pretty_print(result) + '\n')
 
     sys.exit(len(_failed_claim_ids))

--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -348,7 +348,7 @@ def exec_foundry_prove(
     _failed_claim_ids = [cid for cid, _ in failed_claims]
 
     if _failed_claim_ids:
-        for (cid,result) in failed_claims:
+        for (cid, result) in failed_claims:
             print(f'Failed to prove KCFG: {cid}\n')
             print(kevm.pretty_print(result) + '\n')
 


### PR DESCRIPTION
The latest master doesn't print the output of failing proofs on KEVM when running:
```
make tests/foundry/out/kompiled/foundry.k.prove
```
 This PR intends to fix that. For each failing proof it pretty prints the result of the failing proof. 