### PR TITLE
Add configuration for cheat codes

### DIFF
--- a/foundry.md
+++ b/foundry.md
@@ -78,6 +78,12 @@ module FOUNDRY
     imports FOUNDRY-SUCCESS
     imports FOUNDRY-CHEAT-CODES
     imports FOUNDRY-ACCOUNTS
+
+    configuration
+     <foundry>
+         <kevm/>
+         <cheatcodes/>
+     </foundry>
 endmodule
 ```
 
@@ -133,11 +139,29 @@ endmodule
 ```
 
 ### Foundry Cheat Codes
-
+The configuration of the Foundry Cheat Codes is defined as follwing:
+1. The `<prank>` subconfiguration stores values which are used during the execution of any kind of `prank` cheatcode:
+    - `<prevId>` keeps the current address of the contract that initiated the prank.
+    - `<prevOrigin>` keeps the current address of the `tx.origin` value.
+    - `<newId>` and `<newOrigin>` are addresses to be assigned after the prank call to `msg.sender` and `tx.origin`.
+    - `<depth>` records the current call depth at which the prank was invoked.
+    - `<singleCall>` tells whether the prank stops by itself after the next call or when a `stopPrank` cheat code is invoked.
 ```k
 module FOUNDRY-CHEAT-CODES
     imports EVM
     imports FOUNDRY-ACCOUNTS
+
+    configuration
+     <cheatcodes>
+        <prank>
+            <prevId> .Account </prevId>
+            <prevOrigin> .Account </prevOrigin>
+            <newId> .Account </newId>
+            <newOrigin> .Account </newOrigin>
+            <depth> 0 </depth>
+            <singleCall> false </singleCall>
+        </prank>
+     </cheatcodes>
 ```
 
 First we have some helpers in K which can:

--- a/foundry.md
+++ b/foundry.md
@@ -139,6 +139,7 @@ endmodule
 ```
 
 ### Foundry Cheat Codes
+
 The configuration of the Foundry Cheat Codes is defined as follwing:
 1. The `<prank>` subconfiguration stores values which are used during the execution of any kind of `prank` cheatcode:
     - `<prevId>` keeps the current address of the contract that initiated the prank.
@@ -146,6 +147,7 @@ The configuration of the Foundry Cheat Codes is defined as follwing:
     - `<newId>` and `<newOrigin>` are addresses to be assigned after the prank call to `msg.sender` and `tx.origin`.
     - `<depth>` records the current call depth at which the prank was invoked.
     - `<singleCall>` tells whether the prank stops by itself after the next call or when a `stopPrank` cheat code is invoked.
+
 ```k
 module FOUNDRY-CHEAT-CODES
     imports EVM

--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -14,7 +14,7 @@ from pyk.ktool.krun import _krun
 from pyk.prelude.ml import mlTop
 
 from .gst_to_kore import gst_to_kore
-from .kevm import KEVM
+from .kevm import KEVM, Foundry
 from .solc_to_k import Contract, contract_to_claims, contract_to_main_module, solc_compile
 from .utils import KCFG_from_claim, KPrint_make_unparsing, KProve_prove_claim, add_include_arg
 
@@ -174,9 +174,9 @@ def exec_foundry_kompile(
     if reinit or not kcfgs_file.exists():
         _LOGGER.info(f'Initializing KCFGs: {kcfgs_file}')
 
-        kevm = KEVM(foundry_definition_dir, main_file=foundry_main_file, profile=profile)
+        foundry = Foundry(definition_dir, profile=profile)
         cfgs = _contract_to_claim_cfgs(
-            definition=kevm.definition,
+            definition=foundry.definition,
             definition_dir=definition_dir,
             profile=profile,
             contracts=contracts,
@@ -215,8 +215,8 @@ def _foundry_to_bin_runtime(
     requires: Iterable[str],
     imports: Iterable[str],
 ) -> KDefinition:
-    kevm = KEVM(definition_dir, profile=profile)
-    empty_config = kevm.definition.empty_config(KEVM.Sorts.KEVM_CELL)
+    foundry = Foundry(definition_dir, profile=profile)
+    empty_config = foundry.definition.empty_config(Foundry.Sorts.FOUNDRY_CELL)
 
     modules = []
     for contract in contracts:
@@ -244,8 +244,8 @@ def _contract_to_claim_cfgs(
     profile: bool,
     contracts: Iterable[Contract],
 ) -> Dict[str, Dict]:
-    kevm = KEVM(definition_dir, profile=profile)
-    empty_config = kevm.definition.empty_config(KEVM.Sorts.KEVM_CELL)
+    foundry = Foundry(definition_dir, profile=profile)
+    empty_config = foundry.definition.empty_config(Foundry.Sorts.FOUNDRY_CELL)
 
     cfgs: Dict[str, Dict] = {}
     for contract in contracts:

--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -141,8 +141,8 @@ def exec_foundry_kompile(
     json_paths = _contract_json_paths(foundry_out)
     contracts = [_contract_from_json(json_path) for json_path in json_paths]
 
-    kevm = KEVM(definition_dir, profile=profile)
-    empty_config = kevm.definition.empty_config(KEVM.Sorts.KEVM_CELL)
+    foundry = Foundry(definition_dir, profile=profile)
+    empty_config = foundry.definition.empty_config(Foundry.Sorts.FOUNDRY_CELL)
 
     bin_runtime_definition = _foundry_to_bin_runtime(
         empty_config=empty_config,
@@ -155,9 +155,9 @@ def exec_foundry_kompile(
     if regen or not foundry_main_file.exists():
         with open(foundry_main_file, 'w') as fmf:
             _LOGGER.info(f'Writing file: {foundry_main_file}')
-            _kevm = KEVM(definition_dir=definition_dir)
-            _kprint = KPrint_make_unparsing(_kevm, extra_modules=bin_runtime_definition.modules)
-            KEVM._patch_symbol_table(_kprint.symbol_table)
+            _foundry = Foundry(definition_dir=definition_dir)
+            _kprint = KPrint_make_unparsing(_foundry, extra_modules=bin_runtime_definition.modules)
+            Foundry._patch_symbol_table(_kprint.symbol_table)
             fmf.write(_kprint.pretty_print(bin_runtime_definition) + '\n')
 
     if regen or rekompile or not kompiled_timestamp.exists():

--- a/kevm-pyk/src/kevm_pyk/kevm.py
+++ b/kevm-pyk/src/kevm_pyk/kevm.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Final, Iterable, List, Optional
 from pyk.cli_utils import run_process
 from pyk.kast import KApply, KInner, KLabel, KSort, KToken, KVariable, build_assoc
 from pyk.kastManip import flatten_label, get_cell
-from pyk.ktool import KProve, KRun
+from pyk.ktool import KPrint, KProve, KRun
 from pyk.ktool.kprint import paren
 from pyk.prelude.kbool import notBool
 from pyk.prelude.kint import intToken
@@ -316,7 +316,15 @@ class KEVM(KProve, KRun):
         return build_assoc(KApply('.AccountCellMap'), KLabel('_AccountCellMap_'), accts)
 
 
-class Foundry:
+class Foundry(KPrint):
+    def __init__(self, definition_dir: Path, use_directory: Optional[Path] = None, profile: bool = False) -> None:
+         # copied from KEVM class and adapted to inherit KPrint instead
+         KPrint.__init__(self, definition_dir, use_directory=use_directory, profile=profile)
+         KEVM._patch_symbol_table(self.symbol_table)
+
+    class Sorts:
+        FOUNDRY_CELL: Final = KSort('FoundryCell')
+
     @staticmethod
     def success(s: KInner, dst: KInner) -> KApply:
         return KApply('foundry_success ', [s, dst])

--- a/kevm-pyk/src/kevm_pyk/kevm.py
+++ b/kevm-pyk/src/kevm_pyk/kevm.py
@@ -318,9 +318,9 @@ class KEVM(KProve, KRun):
 
 class Foundry(KPrint):
     def __init__(self, definition_dir: Path, use_directory: Optional[Path] = None, profile: bool = False) -> None:
-         # copied from KEVM class and adapted to inherit KPrint instead
-         KPrint.__init__(self, definition_dir, use_directory=use_directory, profile=profile)
-         KEVM._patch_symbol_table(self.symbol_table)
+        # copied from KEVM class and adapted to inherit KPrint instead
+        KPrint.__init__(self, definition_dir, use_directory=use_directory, profile=profile)
+        KEVM._patch_symbol_table(self.symbol_table)
 
     class Sorts:
         FOUNDRY_CELL: Final = KSort('FoundryCell')

--- a/kevm-pyk/src/kevm_pyk/kevm.py
+++ b/kevm-pyk/src/kevm_pyk/kevm.py
@@ -320,10 +320,14 @@ class Foundry(KPrint):
     def __init__(self, definition_dir: Path, use_directory: Optional[Path] = None, profile: bool = False) -> None:
         # copied from KEVM class and adapted to inherit KPrint instead
         KPrint.__init__(self, definition_dir, use_directory=use_directory, profile=profile)
-        KEVM._patch_symbol_table(self.symbol_table)
+        Foundry._patch_symbol_table(self.symbol_table)
 
     class Sorts:
         FOUNDRY_CELL: Final = KSort('FoundryCell')
+
+    @staticmethod
+    def _patch_symbol_table(symbol_table: Dict[str, Any]) -> None:
+        KEVM._patch_symbol_table(symbol_table)
 
     @staticmethod
     def success(s: KInner, dst: KInner) -> KApply:


### PR DESCRIPTION
Created a new configuration named `<cheatcodes/>` which contains cells that are used during the execution of various cheatcodes.
Currently it only holds cells for cheatcodes involving `pranks`.
This configuration, together with the one of `<kevm/>` will form the main configuration of the project, `<foundry/>`.

