### PR TITLE
Update KCFG generation to use Foundry configuration

### DIFF
--- a/foundry.md
+++ b/foundry.md
@@ -142,9 +142,9 @@ endmodule
 
 The configuration of the Foundry Cheat Codes is defined as follwing:
 1. The `<prank>` subconfiguration stores values which are used during the execution of any kind of `prank` cheatcode:
-    - `<prevId>` keeps the current address of the contract that initiated the prank.
+    - `<prevCaller>` keeps the current address of the contract that initiated the prank.
     - `<prevOrigin>` keeps the current address of the `tx.origin` value.
-    - `<newId>` and `<newOrigin>` are addresses to be assigned after the prank call to `msg.sender` and `tx.origin`.
+    - `<newCaller>` and `<newOrigin>` are addresses to be assigned after the prank call to `msg.sender` and `tx.origin`.
     - `<depth>` records the current call depth at which the prank was invoked.
     - `<singleCall>` tells whether the prank stops by itself after the next call or when a `stopPrank` cheat code is invoked.
 
@@ -156,9 +156,9 @@ module FOUNDRY-CHEAT-CODES
     configuration
      <cheatcodes>
         <prank>
-            <prevId> .Account </prevId>
+            <prevCaller> .Account </prevCaller>
             <prevOrigin> .Account </prevOrigin>
-            <newId> .Account </newId>
+            <newCaller> .Account </newCaller>
             <newOrigin> .Account </newOrigin>
             <depth> 0 </depth>
             <singleCall> false </singleCall>

--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -176,7 +176,7 @@ def exec_foundry_kompile(
     if reinit or not kcfgs_file.exists():
         _LOGGER.info(f'Initializing KCFGs: {kcfgs_file}')
 
-        foundry = Foundry(definition_dir, profile=profile)
+        foundry = Foundry(foundry_definition_dir, profile=profile)
         cfgs = _contract_to_claim_cfgs(kevm=foundry, contracts=contracts)
 
         with open(kcfgs_file, 'w') as kf:

--- a/kevm-pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm-pyk/src/kevm_pyk/solc_to_k.py
@@ -329,7 +329,7 @@ def contract_to_main_module(contract: Contract, empty_config: KInner, imports: I
 
 def contract_to_claims(kevm: KPrint, contract: Contract) -> Tuple[str, List[KClaim]]:
     definition = kevm.definition
-    empty_config = definition.empty_config(KEVM.Sorts.KEVM_CELL)
+    empty_config = definition.empty_config(Foundry.Sorts.FOUNDRY_CELL)
     module_name = Contract.contract_to_module_name(contract.name, spec=True)
     test_methods = [method for method in contract.methods if method.name.startswith('test')]
     claims = [_test_execution_claim(empty_config, contract, method) for method in test_methods]


### PR DESCRIPTION
Missed a change in #1398 which prevented the kcfgs to be generated with the Foundry configuration.
Updated the cheat codes configuration cell names which refer to the `caller`.