### PR TITLE
added rules for ecrecoverloop00-sig1-invalid-spec

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -1,4 +1,3 @@
-tests/specs/benchmarks/ecrecoverloop00-sig1-invalid-spec.k
 tests/specs/bihu/collectToken-spec.k
 tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
 tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -3,3 +3,4 @@ tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
 tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
 tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
 tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
+tests/specs/opcodes/create-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -3,4 +3,3 @@ tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
 tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
 tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
 tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
-tests/specs/opcodes/create-spec.k

--- a/tests/specs/benchmarks/ecrecoverloop00-sig1-invalid-spec.k
+++ b/tests/specs/benchmarks/ecrecoverloop00-sig1-invalid-spec.k
@@ -137,7 +137,8 @@ _
      andBool #rangeBytes(32, SIGR1)
      andBool #rangeBytes(32, SIGS0)
      andBool #rangeBytes(32, SIGS1)
-     andBool #ecrecEmpty( #bufStrict(32, HASH), #bufStrict(32, SIGV1), #bufStrict(32, SIGR1), #bufStrict(32, SIGS1) )
-
+     andBool notBool #ecrecEmpty( #bufStrict(32, HASH), #bufStrict(32, SIGV0), #bufStrict(32, SIGR0), #bufStrict(32, SIGS0) )
+     andBool         #ecrecEmpty( #bufStrict(32, HASH), #bufStrict(32, SIGV1), #bufStrict(32, SIGR1), #bufStrict(32, SIGS1) )
+     
 endmodule
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -153,9 +153,8 @@ module VERIFICATION-HASKELL [symbolic, kore]
 
     rule 0 <Int #asWord ( #ecrec( HASH, SIGV, SIGR, SIGS ) ) => notBool ( #ecrecEmpty ( HASH, SIGV, SIGR, SIGS ) )  [simplification]
     
-    // <Int <=/=> <=Int (to debug ecreoverloop00-sig1-invalid-spec)
-    rule A  <Int B => #Not ( { true #Equals B <=Int A } ) [simplification]
-    rule A <=Int B => #Not ( { true #Equals B  <Int A } ) [simplification]
+    // <Int => <=Int (to debug ecreoverloop00-sig1-invalid-spec)
+    rule A <Int B => A <=Int B [simplification] 
 
 endmodule
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -152,9 +152,6 @@ module VERIFICATION-HASKELL [symbolic, kore]
     rule ( #sizeByteArray(#ecrec( _, _, _, _ )) <=Int K ) => true requires 32 <=Int K [simplification]
 
     rule 0 <Int #asWord ( #ecrec( HASH, SIGV, SIGR, SIGS ) ) => notBool ( #ecrecEmpty ( HASH, SIGV, SIGR, SIGS ) )  [simplification]
-    
-    // <Int => <=Int (to debug ecreoverloop00-sig1-invalid-spec)
-    rule A <Int B => A <=Int B [simplification] 
 
 endmodule
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -132,6 +132,10 @@ module VERIFICATION
     rule X <=Int #ceil32(X)     => true   requires 0 <=Int X                       [simplification]
     rule #ceil32(X) <Int X      => false  requires 0 <=Int X                       [simplification]
     rule #ceil32(X) <=Int pow16 => true   requires 0 <=Int X andBool X <=Int pow16 [simplification]
+    
+    // for debugging ecrecoverloop00-sig1-invalid-spec
+    rule A  <Int B => #Not ( { true #Equals B <=Int A } ) [simplification]
+    rule A <=Int B => #Not ( { true #Equals B  <Int A } ) [simplification]
 
 endmodule
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -132,10 +132,6 @@ module VERIFICATION
     rule X <=Int #ceil32(X)     => true   requires 0 <=Int X                       [simplification]
     rule #ceil32(X) <Int X      => false  requires 0 <=Int X                       [simplification]
     rule #ceil32(X) <=Int pow16 => true   requires 0 <=Int X andBool X <=Int pow16 [simplification]
-    
-    // for debugging ecrecoverloop00-sig1-invalid-spec
-    rule A  <Int B => #Not ( { true #Equals B <=Int A } ) [simplification]
-    rule A <=Int B => #Not ( { true #Equals B  <Int A } ) [simplification]
 
 endmodule
 
@@ -156,6 +152,10 @@ module VERIFICATION-HASKELL [symbolic, kore]
     rule ( #sizeByteArray(#ecrec( _, _, _, _ )) <=Int K ) => true requires 32 <=Int K [simplification]
 
     rule 0 <Int #asWord ( #ecrec( HASH, SIGV, SIGR, SIGS ) ) => notBool ( #ecrecEmpty ( HASH, SIGV, SIGR, SIGS ) )  [simplification]
+    
+    // <Int <=/=> <=Int (to debug ecreoverloop00-sig1-invalid-spec)
+    rule A  <Int B => #Not ( { true #Equals B <=Int A } ) [simplification]
+    rule A <=Int B => #Not ( { true #Equals B  <Int A } ) [simplification]
 
 endmodule
 


### PR DESCRIPTION
## Possible solution for failed proof for ecrecoverloop00-sig1-invalid-spec

**Problem:** Failed proof for ecrecoverloop00-sig1-invalid-spec
**Possible solution:** Added the following two rules in `tests/specs/benchmarks/verification.k` to debug ecrecoverloop00-sig1-invalid-spec:
```k
// for debugging ecrecoverloop00-sig1-invalid-spec
    rule A  <Int B => #Not ( { true #Equals B <=Int A } ) [simplification]
    rule A <=Int B => #Not ( { true #Equals B  <Int A } ) [simplification]
```
> **Note:** I am not sure if the above rules should be added in `tests/specs/benchmarks/verification.k` or `tests/specs/int-simplification.k`.

## Details
As pointed out in https://github.com/runtimeverification/haskell-backend/issues/2997, the proof of ecrecoverloop00-sig1-invalid-spec will fail due execution gets stuck with the following content of k cell:
```k
JUMPI 559 bool2Word ( 0 <Int maxUInt160 &Int #asWord ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ++ #range ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01`" [ 128 := #buf ( 32 , SIGV0:Int ) ++ #buf ( 32 , SIGV1:Int ) ] [ 192 := #buf ( 32 , SIGR0:Int ) ++ #buf ( 32 , SIGR1:Int ) ] [ 256 := #buf ( 32 , SIGS0:Int ) ++ #buf ( 32 , SIGS1:Int ) ] [ 320 := b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" ] , #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) +Int 320 , 32 -Int #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) ) ) ) ~> #pc [ JUMPI ] ~> #execute ~> _Gen0:K
```
 One can find this cause by running `kevm prove` for `ecrecoverloop00-sig1-invalid-spec.k` through `Kore Repl`, i.e.,
```
cd evm-semantics
kevm prove tests/specs/benchmarks/ecrecoverloop00-sig1-invalid-spec.k --backend haskell --definition tests/specs/benchmarks/verification/haskell --debugger
```
and produce the graph through `graph` after stepping forward for say 3000 steps, i.e., `stepf 3000`.

The part of the graph that we concern about is the following:
![Screenshot from 2022-09-30 12-42-32](https://user-images.githubusercontent.com/9103507/193191795-d05a1dfc-285d-4bf4-a63a-6a240b19314a.png)

---

### `konfig` of the crucial nodes

**Node 1760:** This is the node where the `JUMPI` command is waiting to be executed:
```k
<k>
      JUMPI 559 bool2Word ( 0 <Int maxUInt160 &Int #asWord ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ++ #range ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01`" [ 128 := #buf ( 32 , SIGV0:Int ) ++ #buf ( 32 , SIGV1:Int ) ] [ 192 := #buf ( 32 , SIGR0:Int ) ++ #buf ( 32 , SIGR1:Int ) ] [ 256 := #buf ( 32 , SIGS0:Int ) ++ #buf ( 32 , SIGS1:Int ) ] [ 320 := b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" ] , #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) +Int 320 , 32 -Int #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) ) ) ) ~> #pc [ JUMPI ] ~> #execute ~> _Gen0:K
</k>
```

**Node 1761:** This is the node where `bool2Word ( 0 <Int maxUInt160 &Int #asWord ( #ecrec ( ... ) ++ #range ( ... ) ) )` is evaluated to 0, i.e., `0 <Int maxUInt160 &Int #asWord ( #ecrec ( ... ) ++ #range ( ... ) )` is false, which will be rewritten to `0 <Int maxUInt160 &Int #asWord ( #ecrec ( ... ) ++ #range ( ... ) ) <= 0` via the following rule found in `tests/specs/int-simplification.k`: 
```k
rule notBool (A  <Int B) => B <=Int A [simplification]
```
as shown in the `konfig` of node 1761:
```k
...
#And
  {
    true
  #Equals
    maxUInt160 &Int #asWord ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ++ #range ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01`" [ 128 := #buf ( 32 , SIGV0:Int ) ++ #buf ( 32 , SIGV1:Int ) ] [ 192 := #buf ( 32 , SIGR0:Int ) ++ #buf ( 32 , SIGR1:Int ) ] [ 256 := #buf ( 32 , SIGS0:Int ) ++ #buf ( 32 , SIGS1:Int ) ] [ 320 := b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" ] , #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) +Int 320 , 32 -Int #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) ) ) <=Int 0
  }
...
```

**Node 1762:** This is the node where `bool2Word ( 0 <Int maxUInt160 &Int #asWord ( #ecrec ( ... ) ++ #range ( ... ) ) )` is evaluated to 1, i.e., `0 <Int maxUInt160 &Int #asWord ( #ecrec ( ... ) ++ #range ( ... ) )` is true, which is shown in the `konfig` of node 1762:
```k
...
#And
  {
    true
  #Equals
    0 <Int maxUInt160 &Int #asWord ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ++ #range ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01`" [ 128 := #buf ( 32 , SIGV0:Int ) ++ #buf ( 32 , SIGV1:Int ) ] [ 192 := #buf ( 32 , SIGR0:Int ) ++ #buf ( 32 , SIGR1:Int ) ] [ 256 := #buf ( 32 , SIGS0:Int ) ++ #buf ( 32 , SIGS1:Int ) ] [ 320 := b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" ] , #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) +Int 320 , 32 -Int #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) ) )
  }
...
```

**Node 1763:** This is the (unexpected) node where `0 <Int maxUInt160 &Int #asWord ( #ecrec ( ... ) ++ #range ( ... ) )` is false and true at the same time, which is shown in the `konfig` of node 1763:
```k
#And
  #Not ( {
    true
  #Equals
    0 <Int maxUInt160 &Int #asWord ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ++ #range ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01`" [ 128 := #buf ( 32 , SIGV0:Int ) ++ #buf ( 32 , SIGV1:Int ) ] [ 192 := #buf ( 32 , SIGR0:Int ) ++ #buf ( 32 , SIGR1:Int ) ] [ 256 := #buf ( 32 , SIGS0:Int ) ++ #buf ( 32 , SIGS1:Int ) ] [ 320 := b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" ] , #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) +Int 320 , 32 -Int #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) ) )
  } )
#And
  #Not ( {
    true
  #Equals
    maxUInt160 &Int #asWord ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ++ #range ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01`" [ 128 := #buf ( 32 , SIGV0:Int ) ++ #buf ( 32 , SIGV1:Int ) ] [ 192 := #buf ( 32 , SIGR0:Int ) ++ #buf ( 32 , SIGR1:Int ) ] [ 256 := #buf ( 32 , SIGS0:Int ) ++ #buf ( 32 , SIGS1:Int ) ] [ 320 := b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" ] , #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) +Int 320 , 32 -Int #sizeByteArray ( #ecrec ( #buf ( 32 , HASH:Int ) , #buf ( 32 , SIGV0:Int ) , #buf ( 32 , SIGR0:Int ) , #buf ( 32 , SIGS0:Int ) ) ) ) ) <=Int 0
  } )
```

**Possible reasons for node 1763:**
1) Simplification of `0 <Int maxUInt160 &Int #asWord (#ecrec ( ... ) ++ #range ( ... ) )` to `0 <Int #asWord (#ecrec ( ... ) ++ #range ( ... ) )` did not occur prior to node 1760. If it occurs, the prover should be able to figure it out.
2) The prover does not know that `<=Int` is total ordering, i.e., if `A <Int B`, then `B <=Int A` cannot hold.

---

### Attempt/s to tackle reason 1

To tackle reason A, I added the following rules to "force" the simplification of `0 <Int maxUInt160 &Int #asWord (#ecrec ( ... ) ++ #range ( ... ) )` to `0 <Int #asWord (#ecrec ( ... ) ++ #range ( ... ) )`:
```k
rule 0 <=Int #asWord( _ ) => true [simplification]
rule #asWord(#ecrec(_   , _   , _   , _   ) ++ _ ) <=Int maxUInt160 => true [simplification]
```
But the same problem still persists, i.e., `0 <Int #asWord ( #ecrec ( ... ) ++ #range ( ... ) )` is false and true at the same time, as shown in the following `konfig`:
```k
...
#And
  #Not ( {
    true
  #Equals
    0 <Int #asWord ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV0 ) , #buf ( 32 , SIGR0 ) , #buf ( 32 , SIGS0 ) ) ++ #range ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01`" [ 128 := #buf ( 32 , SIGV0 ) ++ #buf ( 32 , SIGV1 ) ] [ 192 := #buf ( 32 , SIGR0 ) ++ #buf ( 32 , SIGR1 ) ] [ 256 := #buf ( 32 , SIGS0 ) ++ #buf ( 32 , SIGS1 ) ] [ 320 := b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" ] , #sizeByteArray ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV0 ) , #buf ( 32 , SIGR0 ) , #buf ( 32 , SIGS0 ) ) ) +Int 320 , 32 -Int #sizeByteArray ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV0 ) , #buf ( 32 , SIGR0 ) , #buf ( 32 , SIGS0 ) ) ) ) )
  } )
#And
  #Not ( {
    true
  #Equals
    #asWord ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV0 ) , #buf ( 32 , SIGR0 ) , #buf ( 32 , SIGS0 ) ) ++ #range ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01`" [ 128 := #buf ( 32 , SIGV0 ) ++ #buf ( 32 , SIGV1 ) ] [ 192 := #buf ( 32 , SIGR0 ) ++ #buf ( 32 , SIGR1 ) ] [ 256 := #buf ( 32 , SIGS0 ) ++ #buf ( 32 , SIGS1 ) ] [ 320 := b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" ] , #sizeByteArray ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV0 ) , #buf ( 32 , SIGR0 ) , #buf ( 32 , SIGS0 ) ) ) +Int 320 , 32 -Int #sizeByteArray ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV0 ) , #buf ( 32 , SIGR0 ) , #buf ( 32 , SIGS0 ) ) ) ) ) <=Int 0
  } )
#And
  <kevm>
    <k>
      JUMPI 559 bool2Word ( 0 <Int #asWord ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV0 ) , #buf ( 32 , SIGR0 ) , #buf ( 32 , SIGS0 ) ) ++ #range ( b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01`" [ 128 := #buf ( 32 , SIGV0 ) ++ #buf ( 32 , SIGV1 ) ] [ 192 := #buf ( 32 , SIGR0 ) ++ #buf ( 32 , SIGR1 ) ] [ 256 := #buf ( 32 , SIGS0 ) ++ #buf ( 32 , SIGS1 ) ] [ 320 := b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" ] , #sizeByteArray ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV0 ) , #buf ( 32 , SIGR0 ) , #buf ( 32 , SIGS0 ) ) ) +Int 320 , 32 -Int #sizeByteArray ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV0 ) , #buf ( 32 , SIGR0 ) , #buf ( 32 , SIGS0 ) ) ) ) ) ) ~> #pc [ JUMPI ] ~> #execute ~> _Gen0 ~> .
    </k>
...
...
```
---

### Attempt/s to tackle reason 2

The following are the attempts to introduce rules to the `tests/specs/benchmarks/verification.k` under the `VERIFICATION` module (the last one is the only one that succeeded):

- Attempt 1:
```k
rule #Not ( { true #Equals I1 <=Int I2 } ) => { true #Equals I2 <Int I1 } [simplification]
```

- Attempt 2:
```k
rule (A <Int B) andBool (B <=Int A) => false [simplification]
```

- Attempt 3:
```k
rule (notBool (A <Int B)) andBool (notBool (B <=Int A)) => false [simplification]
```

- Attempt 4:
```k
rule (A <Int B) orBool (B <=Int A) => true [simplification]
```

- Attempt 5:
```k
rule (A <Int B) andBool (B <=Int A) => false requires (A <Int B) orBool (B <=Int A) [simplification]
```

- Attempt 6:
```k
rule (notBool (A <Int B)) andBool (notBool (B <=Int A)) => false requires (A <Int B) orBool (B <=Int A) [simplification]
```

- Attempt 7 (the process went on for >30min, so I guess there is a loop of rewriting):
```k
rule A  <Int B => notBool (B <=Int A) [simplification]
rule A <=Int B => notBool (B  <Int A) [simplification]
```

- Attempt 8 (the process went on for >30min, so I guess there is a loop of rewriting):
```k
rule A  <Int B => false requires B <=Int A [simplification]
rule A <=Int B => false requires B  <Int A [simplification]
```

- Attempt 9 (the process went on for >30min, so I guess there is a loop of rewriting):
```k
rule A  <Int B => true requires notBool (B <=Int A) [simplification]
rule A <=Int B => true requires notBool (B  <Int A) [simplification]
```

- Attempt 10 (completed the proof in around 6 min):
```k
rule A  <Int B => #Not ( { true #Equals B <=Int A } ) [simplification]
rule A <=Int B => #Not ( { true #Equals B  <Int A } ) [simplification]
```
---

### Existing rules that might be helpful in the debugging process:

- In `tests/specs/int-simplification.k`:
```k
rule notBool (A  <Int B) => B <=Int A [simplification]
rule notBool (A <=Int B) => B  <Int A [simplification]
```

- In `tests/specs/benchmarks/verification.k`:
```k
rule 0 <=Int #asWord(#ecrec(_   , _   , _   , _   ))                  => true                                                      [simplification]
rule         #asWord(#ecrec(_   , _   , _   , _   )) <=Int maxUInt160 => true                                                      [simplification]

rule #asWord(WS) &Int maxUInt256 => #asWord(WS) [simplification]

rule maxUInt256 &Int X => X requires #rangeUInt(256, X) [simplification]

rule maxUInt160 &Int Y => Y requires 0 <=Int Y andBool Y <=Int maxUInt160 [simplification]
```
---