### PR TITLE
Run nix build on M1

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -147,7 +147,7 @@ jobs:
             substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v12
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -140,6 +140,7 @@ jobs:
           sudo apt-add-repository ppa:deadsnakes/ppa
           sudo apt-get install --yes python3.10
       - name: 'Install Nix'
+        if: ${{ !startsWith(matrix.os, 'self') }}
         uses: cachix/install-nix-action@v15
         with:
           install_url: https://releases.nixos.org/nix/nix-2.7.0/install

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -119,8 +119,14 @@ jobs:
     name: 'Nix'
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest]
-    runs-on: ${{ matrix.os }}
+        include:
+          - runner: ubuntu-20.04
+            os: ubuntu-20.04
+          - runner: macos-12
+            os: macos-12
+          - runner: MacM1
+            os: self-macos-12
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v3

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -147,7 +147,8 @@ jobs:
             substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v12
+        if: ${{ !startsWith(matrix.os, 'self') }}
+        uses: cachix/cachix-action@v10
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'


### PR DESCRIPTION
This PR makes a small change to include the M1 machine in the job matrix for the KEVM Nix tests, as well as ensuring that Nix and Cachix don't get installed on that machine. The changes made here mirror the CI setup for K, the LLVM backend etc. and are not novel.

Because the format of the job matrix has changed, the required checks will need to be updated in the repo settings.