### PR TITLE
Retry failing foundry proof once on CI

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -109,7 +109,7 @@ jobs:
       - name: 'Build Foundry'
         run: docker exec -t kevm-ci-foundry-${GITHUB_SHA} /bin/bash -c 'make build-foundry -j2'
       - name: 'Test Foundry'
-        run: docker exec -t kevm-ci-foundry-${GITHUB_SHA} /bin/bash -c 'make test-foundry -j2 FOUNDRY_PAR=4'
+        run: docker exec -t kevm-ci-foundry-${GITHUB_SHA} /bin/bash -c 'make test-foundry -j2 FOUNDRY_PAR=4 KPROVE_OPTS=--retry'
       - name: 'Tear down Docker'
         if: always()
         run: |


### PR DESCRIPTION
Currently, the `foundry-prove` stage often fails due to resource exhaustion.
Added a new argument to `foundry-prove` named `--retry`, marked as `False` by default, and would rerun all the failing proofs once.