### PR TITLE
[nix] Fix profiling script

### DIFF
--- a/package/nix/profile.nix
+++ b/package/nix/profile.nix
@@ -16,12 +16,17 @@ in stdenv.mkDerivation {
   inherit src;
   preferLocalBuild = true;
   buildInputs = [ kevm ];
+  postPatch = ''
+    substituteInPlace ./Makefile \
+      --replace 'venv: $(VENV_DIR)/pyvenv.cfg' 'venv:'
+  '';
+  
   buildPhase = ''
     mkdir -p .build/usr
     cp -r ${kevm}/* .build/usr/
     ${kore-exec}/bin/kore-exec --version &> log
-    make build-prove-haskell -j4
-    make test-prove-smoke TEST_SYMBOLIC_BACKEND=haskell KEVM='${profile}/bin/profile log timeout 600 kevm' -j6 -k
+    make build-prove-haskell PYK_ACTIVATE=true -j4
+    make test-prove-smoke PYK_ACTIVATE=true TEST_SYMBOLIC_BACKEND=haskell KEVM='${profile}/bin/profile log timeout 600 kevm' -j6 -k
   '';
   enableParallelBuilding = true;
   installPhase = ''


### PR DESCRIPTION
The Makefile had been modified to call venv for various proofs at some point. However, this breaks nix, since we don't rely on `venv` and instead supply a custom build of python on the PATH with all the required deps.