### PR TITLE
Request for Comment: Limit size of calldata arrays to 2^128 bytes

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kevm.py
+++ b/kevm-pyk/src/kevm_pyk/kevm.py
@@ -234,6 +234,15 @@ class KEVM(KProve, KRun):
     def range_bytes(width: KInner, ba: KInner) -> KApply:
         return KApply('#rangeBytes(_,_)_WORD_Bool_Int_Int', [width, ba])
 
+    # We can realistically say that, when using memory or calldata, the size of
+    # the array is less than 2**128 bytes, which is still 300 quintillion
+    # exabytes. This will not realistically fit in a transaction, within any gas
+    # limit, or be possible to allocate on any machine, so this limit is a good
+    # working assumption.
+    @staticmethod
+    def range_array_calldata(ba: KInner) -> KApply:
+        return KApply('_<Int_', [KApply('#sizeByteArray(_)_EVM-TYPES_Int_ByteArray', [ba]), intToken(2**128)])
+
     @staticmethod
     def bool_2_word(cond: KInner) -> KApply:
         return KApply('bool2Word(_)_EVM-TYPES_Int_Bool', [cond])

--- a/kevm-pyk/src/kevm_pyk/solc_to_k.py
+++ b/kevm-pyk/src/kevm_pyk/solc_to_k.py
@@ -545,7 +545,9 @@ def _range_predicate(term: KInner, type_label: str) -> Optional[KInner]:
         return KEVM.range_uint(256, term)
     if type_label == 'int256':
         return KEVM.range_sint(256, term)
-    if type_label in {'bytes', 'string'}:
+    if type_label == 'bytes':
+        return KEVM.range_array_calldata(term)
+    if type_label == 'string':
         return TRUE
 
     _LOGGER.warning(f'Unknown range predicate for type: {type_label}')


### PR DESCRIPTION
It is helpful when slicing calldata to assume that the size of the byte array is within the addressable range, 2^256 bytes. It's even more helpful to know that the calldata is much smaller than that, to allow some wiggle room for arithmetic:

Motivating example in a side condition:

```
#And ( ( { true #Equals ( ( #sizeByteArray ( #bufStrict ( 32 , #getValue ( #uint256 ( #sizeByteArray ( VV3__data_3c5818c8 ) ) ) ) ) +Int ( ( ( ( #sizeByteArray ( VV3__data_3c5818c8 ) up/Int 32 ) ) *Int 32 ) ) ) ) <Int 115792089237316195423570985008687907853269984665640564039457584007913129639804 }
```

Since calldata needs to be actually allocated and initialized, we can give it realistic constraints.
(Unlike storage, which can just be declared and is implicitly initialized, initializing a storage array as `new bytes[](type(uint256).max)` compiles fine.)
2^128 is a crypotgraphy-strength number. 2^128 bytes would be far more than 10^21 times the amount of data on the deep web. (https://www.wolframalpha.com/input?i=2%5E128+bytes). If we could allocate 64 GB of data per picosecond, it would take 100 million years to generate. So arguably the assumption is safe.

Note that we want to avoid saying that `#sizeByteArray(BS) <Int 128 => true` since this would be unsound, something a theorem prover or SMT solver might discover and decide it has reached bottom.

Instead, we want to say that: the length of any calldata array in EVM is less that 2^128 bytes.

I'm not sure if this is the best way to insert that assumption everywhere, so I'm looking for comments on the approach.