### PR TITLE
Fix ABI encoding of `bytes4` type

### DIFF
--- a/include/kframework/abi.md
+++ b/include/kframework/abi.md
@@ -325,7 +325,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #enc( #int256( DATA )) => #bufStrict(32, #getValue( #int256( DATA )))
     rule #enc( #int128( DATA )) => #bufStrict(32, #getValue( #int128( DATA )))
 
-    rule #enc( #bytes4( DATA )) => #bufStrict(32, #getValue( #bytes4( DATA )))
+    rule #enc( #bytes4( DATA )) => #padRightToWidth(32, #bufStrict(4, #getValue(#bytes4( DATA ))))
     rule #enc(#bytes32( DATA )) => #bufStrict(32, #getValue(#bytes32( DATA )))
 
     rule #enc(   #bool( DATA )) => #bufStrict(32, #getValue(   #bool( DATA )))

--- a/include/kframework/evm-types.md
+++ b/include/kframework/evm-types.md
@@ -435,10 +435,10 @@ The local memory of execution is a byte-array (instead of a word-array).
     syntax ByteArray ::= #padToWidth      ( Int , ByteArray ) [function, total]
                        | #padRightToWidth ( Int , ByteArray ) [function, total]
  // ---------------------------------------------------------------------------
-    rule                        #padToWidth(N, BS)      =>               BS        requires notBool (N >=Int 0)
-    rule [padToWidthNonEmpty] : #padToWidth(N, BS)      =>  padLeftBytes(BS, N, 0) requires          N >=Int 0
-    rule                        #padRightToWidth(N, BS) =>               BS        requires notBool (N >=Int 0)
-    rule                        #padRightToWidth(N, BS) => padRightBytes(BS, N, 0) requires          N >=Int 0
+    rule                            #padToWidth(N, BS)      =>               BS        requires notBool (N >=Int 0)
+    rule [padToWidthNonEmpty]:      #padToWidth(N, BS)      =>  padLeftBytes(BS, N, 0) requires          N >=Int 0
+    rule                            #padRightToWidth(N, BS) =>               BS        requires notBool (N >=Int 0)
+    rule [padRightToWidthNonEmpty]: #padRightToWidth(N, BS) => padRightBytes(BS, N, 0) requires          N >=Int 0
 ```
 
 ```{.k .nobytes}

--- a/include/kframework/lemmas/lemmas.k
+++ b/include/kframework/lemmas/lemmas.k
@@ -134,10 +134,11 @@ module LEMMAS [symbolic]
 
     // sizeByteArray
 
-    rule #sizeByteArray(BUF1 ++ BUF2)            => #sizeByteArray(BUF1) +Int #sizeByteArray(BUF2)      [simplification]
-    rule #sizeByteArray(#buf(SIZE, _))           => SIZE                                                [simplification]
-    rule #sizeByteArray(_MEM [ START .. WIDTH ]) => WIDTH  requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
-    rule #sizeByteArray(#range(_, START, WIDTH)) => WIDTH  requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
+    rule #sizeByteArray(BUF1 ++ BUF2)                 => #sizeByteArray(BUF1) +Int #sizeByteArray(BUF2)      [simplification]
+    rule #sizeByteArray(#buf(SIZE, _))                => SIZE                                                [simplification]
+    rule #sizeByteArray(_MEM [ START .. WIDTH ])      => WIDTH  requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
+    rule #sizeByteArray(#range(_, START, WIDTH))      => WIDTH  requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
+    rule #sizeByteArray(#padRightToWidth(WIDTH, BUF)) => WIDTH  requires #sizeByteArray(BUF) <=Int WIDTH     [simplification]
 
     // TODO: custom ==K unification doesn't work in Haskell yet
     // ++ unification
@@ -146,6 +147,12 @@ module LEMMAS [symbolic]
     rule #padToWidth(32, #asByteStack(V)) => #buf(32, V)  requires #rangeUInt(256, V) [simplification]
 
     rule #asWord(WS) >>Int M => #asWord(WS [ 0 .. #sizeByteArray(WS) -Int (M /Int 8) ])  requires 0 <=Int M andBool M modInt 8 ==Int 0 [simplification]
+
+    rule #asWord(#padRightToWidth(32, BUF)) &Int notMaxUInt224 =>
+         #asWord(#padRightToWidth(32, BUF))
+      requires #sizeByteArray(BUF) <=Int 4 [simplification]
+
+    rule #padRightToWidth(_, BUF)[ 0 .. WIDTH ] => BUF requires #sizeByteArray(BUF) ==Int WIDTH [simplification]
 
 endmodule
 

--- a/kevm-pyk/src/kevm_pyk/kevm.py
+++ b/kevm-pyk/src/kevm_pyk/kevm.py
@@ -161,6 +161,7 @@ class KEVM(KProve, KRun):
             'EVM-TYPES.bytesRange',
             'EVM-TYPES.mapWriteBytes.recursive',
             'EVM-TYPES.#padRightToWidth',
+            'EVM-TYPES.padRightToWidthNonEmpty',
             'EVM-TYPES.#padToWidth',
             'EVM-TYPES.padToWidthNonEmpty',
             'EVM-TYPES.powmod.nonzero',

--- a/tests/foundry/exclude
+++ b/tests/foundry/exclude
@@ -14,6 +14,10 @@ AssumeTest.test_assume_false
 AssumeTest.testFail_assume_false
 AssumeTest.testFail_assume_true
 BroadcastTest.testDeploy
+BytesTypeTest.test_bytes32_fail
+BytesTypeTest.test_bytes4_fail
+BytesTypeTest.testFail_bytes32
+BytesTypeTest.testFail_bytes4
 ContractBTest.testCannotSubtract43
 ContractBTest.testFailSubtract43
 ContractBTest.testNumberIs42

--- a/tests/foundry/foundry.k.check.expected
+++ b/tests/foundry/foundry.k.check.expected
@@ -4264,6 +4264,81 @@ module TOKEN-BIN-RUNTIME
 
 endmodule
 
+module BYTESTYPETEST-BIN-RUNTIME
+    imports public FOUNDRY
+    
+    syntax Contract ::= BytesTypeTestContract
+    
+    syntax BytesTypeTestContract ::= "BytesTypeTest" [symbol(), klabel(contract_BytesTypeTest)]
+    
+      
+    
+    syntax ByteArray ::= BytesTypeTestContract "." BytesTypeTestMethod [function(), symbol(), klabel(method_BytesTypeTest)]
+    
+    syntax BytesTypeTestMethod ::= "setUp" "(" ")" [symbol(), klabel(method_BytesTypeTest_setUp)]
+    
+    syntax BytesTypeTestMethod ::= "testFail_bytes32" "(" Int ")" [symbol(), klabel(method_BytesTypeTest_testFail_bytes32)]
+    
+    syntax BytesTypeTestMethod ::= "testFail_bytes4" "(" Int ")" [symbol(), klabel(method_BytesTypeTest_testFail_bytes4)]
+    
+    syntax BytesTypeTestMethod ::= "test_bytes32" "(" Int ")" [symbol(), klabel(method_BytesTypeTest_test_bytes32)]
+    
+    syntax BytesTypeTestMethod ::= "test_bytes32_fail" "(" Int ")" [symbol(), klabel(method_BytesTypeTest_test_bytes32_fail)]
+    
+    syntax BytesTypeTestMethod ::= "test_bytes4" "(" Int ")" [symbol(), klabel(method_BytesTypeTest_test_bytes4)]
+    
+    syntax BytesTypeTestMethod ::= "test_bytes4_fail" "(" Int ")" [symbol(), klabel(method_BytesTypeTest_test_bytes4_fail)]
+    
+    rule  ( BytesTypeTest . setUp ( ) => #abiCallData ( "setUp" , .TypedArgs ) )
+      
+    
+    rule  ( BytesTypeTest . testFail_bytes32 ( V0_x ) => #abiCallData ( "testFail_bytes32" , #bytes32 ( V0_x ) , .TypedArgs ) )
+       ensures #rangeUInt ( 256 , V0_x )
+      
+    
+    rule  ( BytesTypeTest . testFail_bytes4 ( V0_x ) => #abiCallData ( "testFail_bytes4" , #bytes4 ( V0_x ) , .TypedArgs ) )
+       ensures #rangeBytes ( 4 , V0_x )
+      
+    
+    rule  ( BytesTypeTest . test_bytes32 ( V0_x ) => #abiCallData ( "test_bytes32" , #bytes32 ( V0_x ) , .TypedArgs ) )
+       ensures #rangeUInt ( 256 , V0_x )
+      
+    
+    rule  ( BytesTypeTest . test_bytes32_fail ( V0_x ) => #abiCallData ( "test_bytes32_fail" , #bytes32 ( V0_x ) , .TypedArgs ) )
+       ensures #rangeUInt ( 256 , V0_x )
+      
+    
+    rule  ( BytesTypeTest . test_bytes4 ( V0_x ) => #abiCallData ( "test_bytes4" , #bytes4 ( V0_x ) , .TypedArgs ) )
+       ensures #rangeBytes ( 4 , V0_x )
+      
+    
+    rule  ( BytesTypeTest . test_bytes4_fail ( V0_x ) => #abiCallData ( "test_bytes4_fail" , #bytes4 ( V0_x ) , .TypedArgs ) )
+       ensures #rangeBytes ( 4 , V0_x )
+      
+    
+    rule  ( selector ( "setUp" ) => 177362148 )
+      
+    
+    rule  ( selector ( "testFail_bytes32" ) => 4289330289 )
+      
+    
+    rule  ( selector ( "testFail_bytes4" ) => 3602852570 )
+      
+    
+    rule  ( selector ( "test_bytes32" ) => 3436986189 )
+      
+    
+    rule  ( selector ( "test_bytes32_fail" ) => 392713219 )
+      
+    
+    rule  ( selector ( "test_bytes4" ) => 2814412853 )
+      
+    
+    rule  ( selector ( "test_bytes4_fail" ) => 2510894010 )
+      
+
+endmodule
+
 module UINTTYPETEST-BIN-RUNTIME
     imports public FOUNDRY
     
@@ -6851,6 +6926,7 @@ module FOUNDRY-MAIN
     imports public TESTNUMBER-BIN-RUNTIME
     imports public TOSTRINGTEST-BIN-RUNTIME
     imports public TOKEN-BIN-RUNTIME
+    imports public BYTESTYPETEST-BIN-RUNTIME
     imports public UINTTYPETEST-BIN-RUNTIME
     imports public VM-BIN-RUNTIME
     imports public VM2-BIN-RUNTIME

--- a/tests/foundry/test/TypeTest.t.sol
+++ b/tests/foundry/test/TypeTest.t.sol
@@ -484,3 +484,36 @@ contract UintTypeTest {
     }
 
 }
+
+contract BytesTypeTest {
+    function setUp() public {}
+
+    /* Tests for bytes32 */
+    function test_bytes32(bytes32 x) public pure {
+        assert(x == x);
+        assert(type(uint256).max >= uint256(x));
+    }
+
+    function test_bytes32_fail(bytes32 x) public pure {
+        assert(type(uint256).max > uint256(x));
+    }
+
+    function testFail_bytes32(bytes32 x) public pure {
+        assert(type(uint256).max > uint256(x));
+    }
+
+
+    /* Tests for bytes4 */
+    function test_bytes4(bytes4 x) public pure {
+        assert(x == x);
+        assert(type(uint32).max >= uint32(x));
+    }
+
+    function test_bytes4_fail(bytes4 x) public pure {
+        assert(type(uint32).max > uint32(x));
+    }
+
+    function testFail_bytes4(bytes4 x) public pure {
+        assert(type(uint32).max > uint32(x));
+    }
+}

--- a/tests/specs/concrete-rules.txt
+++ b/tests/specs/concrete-rules.txt
@@ -29,6 +29,7 @@ EVM-TYPES.ByteArray.range
 EVM-TYPES.bytesRange
 EVM-TYPES.mapWriteBytes.recursive
 EVM-TYPES.#padRightToWidth
+EVM-TYPES.padRightToWidthNonEmpty
 EVM-TYPES.#padToWidth
 EVM-TYPES.padToWidthNonEmpty
 EVM-TYPES.powmod.nonzero


### PR DESCRIPTION
* Fixed ABI encoding of `bytes4` type to pad with zeroes on the right instead of the left.
* Marked the rule for `#padRightToWidth` as concrete.
* Created test contract `BytesTypeTest` to test `bytes<N>` support.
* Added 3 new lemmas to `lemmas.k` to get tests for `bytes4` passing verification.