### PR TITLE
refactor #execute rules

### DIFF
--- a/include/kframework/evm.md
+++ b/include/kframework/evm.md
@@ -2725,8 +2725,8 @@ After interpreting the strings representing programs as a `WordStack`, it should
 -   `#dasmOpCode` interperets a `Int` as an `OpCode`.
 
 ```k
-    syntax OpCode ::= #dasmOpCode ( Int , Schedule ) [function, memo]
- // -----------------------------------------------------------------
+    syntax OpCode ::= #dasmOpCode ( Int , Schedule ) [function, memo, total]
+ // ------------------------------------------------------------------------
     rule #dasmOpCode(   0,     _ ) => STOP
     rule #dasmOpCode(   1,     _ ) => ADD
     rule #dasmOpCode(   2,     _ ) => MUL


### PR DESCRIPTION
- add `total` tag to  `#dasmOpCode`
- refactor `#execute` rules to use a lookup function which is totally defined. 