### PR TITLE
Use RPC server to simplify initial states rather than kprove

### DIFF
--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -396,6 +396,7 @@ def exec_foundry_prove(
         return len(failure_nodes) == 0
 
     with ProcessPool(ncpus=workers) as process_pool:
+        foundry.close_kore_rpc()
         results = process_pool.map(prove_it, kcfgs.items())
         process_pool.close()
 

--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -35,6 +35,12 @@ _LOGGER: Final = logging.getLogger(__name__)
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
 
+def _write_cfg(_cfg: KCFG, _cfgpath: Path) -> None:
+    with open(_cfgpath, 'w') as cfgfile:
+        cfgfile.write(json.dumps(_cfg.to_dict()))
+        _LOGGER.info(f'Updated CFG file: {_cfgpath}')
+
+
 def _ignore_arg(args: Dict[str, Any], arg: str, cli_option: str) -> None:
     if arg in args:
         if args[arg] is not None:
@@ -360,11 +366,6 @@ def exec_foundry_prove(
                 kcfgs[test] = (KCFG.from_dict(json.loads(kf.read())), kcfg_file)
 
     lemma_rules = [KRule(KToken(lr, 'K'), att=KAtt({'simplification': ''})) for lr in lemmas]
-
-    def _write_cfg(_cfg: KCFG, _cfgpath: Path) -> None:
-        with open(_cfgpath, 'w') as cfgfile:
-            cfgfile.write(json.dumps(_cfg.to_dict()))
-            _LOGGER.info(f'Updated CFG file: {_cfgpath}')
 
     def prove_it(_id_and_cfg: Tuple[str, Tuple[KCFG, Path]]) -> bool:
         _cfg_id, (_cfg, _cfg_path) = _id_and_cfg

--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -35,10 +35,9 @@ _LOGGER: Final = logging.getLogger(__name__)
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
 
-def _write_cfg(_cfg: KCFG, _cfgpath: Path) -> None:
-    with open(_cfgpath, 'w') as cfgfile:
-        cfgfile.write(json.dumps(_cfg.to_dict()))
-        _LOGGER.info(f'Updated CFG file: {_cfgpath}')
+def write_cfg(_cfg: KCFG, _cfgpath: Path) -> None:
+    _cfgpath.write_text(_cfg.to_json())
+    _LOGGER.info(f'Updated CFG file: {_cfgpath}')
 
 
 def _ignore_arg(args: Dict[str, Any], arg: str, cli_option: str) -> None:
@@ -392,7 +391,7 @@ def exec_foundry_prove(
                 if minimize:
                     result_state = minimize_term(result_state)
                 _LOGGER.error(f'Proof failed: {_cfg_id}\n{foundry.pretty_print(result_state)}')
-        _write_cfg(_cfg, _cfg_path)
+        write_cfg(_cfg, _cfg_path)
         failure_nodes = _cfg.frontier + _cfg.stuck
         return len(failure_nodes) == 0
 

--- a/kevm-pyk/src/kevm_pyk/utils.py
+++ b/kevm-pyk/src/kevm_pyk/utils.py
@@ -23,6 +23,10 @@ from pyk.prelude.kbool import FALSE
 from pyk.prelude.ml import mlAnd
 
 
+def KDefinition__expand_macros(defn: KDefinition, term: KInner) -> KInner:  # noqa: N802
+    return term
+
+
 def KCFG__replace_node(cfg: KCFG, node_id: str, new_cterm: CTerm) -> KCFG:  # noqa: N802
 
     # Remove old node, record data

--- a/kevm-pyk/src/kevm_pyk/utils.py
+++ b/kevm-pyk/src/kevm_pyk/utils.py
@@ -2,7 +2,7 @@ from logging import Logger
 from typing import Collection, Iterable, List, Optional, Tuple
 
 from pyk.cterm import CTerm
-from pyk.kast.inner import KApply, KInner, KVariable, Subst
+from pyk.kast.inner import KApply, KInner, KRewrite, KVariable, Subst
 from pyk.kast.manip import (
     abstract_term_safely,
     bool_to_ml_pred,
@@ -24,6 +24,23 @@ from pyk.prelude.ml import mlAnd
 
 
 def KDefinition__expand_macros(defn: KDefinition, term: KInner) -> KInner:  # noqa: N802
+    def _expand_macros(_term: KInner) -> KInner:
+        if type(_term) is KApply:
+            prod = defn.production_for_klabel(_term.label)
+            if 'macro' in prod.att or 'alias' in prod.att or 'macro-rec' in prod.att or 'alias-rec' in prod.att:
+                for r in defn.macro_rules:
+                    assert type(r.body) is KRewrite
+                    _new_term = r.body.apply_top(_term)
+                    if _new_term != _term:
+                        _term = _new_term
+                        break
+        return _term
+
+    old_term = None
+    while term != old_term:
+        old_term = term
+        term = bottom_up(_expand_macros, term)
+
     return term
 
 


### PR DESCRIPTION
~Blocked on: https://github.com/runtimeverification/evm-semantics/pull/1491~
~Blocked on: https://github.com/runtimeverification/pyk/pull/131~

Simplifying the initial state with textual kprove interface takes about  50s on my machine for each state (which happens once for initial and target). Simplifying it with Kore RPC takes about 10s to launch the server the first time, then 3s to do each simplification.
