### PR TITLE
Correctly build `<accounts>` map

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kevm.py
+++ b/kevm-pyk/src/kevm_pyk/kevm.py
@@ -354,7 +354,14 @@ class KEVM(KProve, KRun):
 
     @staticmethod
     def accounts(accts: List[KInner]) -> KInner:
-        return build_assoc(KApply('.AccountCellMap'), KLabel('_AccountCellMap_'), accts)
+        wrapped_accounts: List[KInner] = []
+        for acct in accts:
+            if type(acct) is KApply and acct.label.name == '<account>':
+                acct_id = acct.args[0]
+                wrapped_accounts.append(KApply('AccountCellMapItem', [acct_id, acct]))
+            else:
+                wrapped_accounts.append(acct)
+        return build_assoc(KApply('.AccountCellMap'), KLabel('_AccountCellMap_'), wrapped_accounts)
 
 
 class Foundry(KEVM):


### PR DESCRIPTION
We are currently building teh `<accounts>` cell map without the wrapping `AccountCellMapItem` constructor around each item. A minimal example of the same problem is shown here: https://github.com/runtimeverification/pyk/pull/142. To see why this is needed, you should inspect `definition.kore` for the rules for `#accountNonexistent` (which exists in teh `*-kompiled` directory).

This causes the generated Kore terms in incremental-exploration to get stuck on any rule that is using the `<accounts>` cell, such as `#accountNonexistant` or `#touchedAccounts` or other account cell accessors.

This should fix that.