### PR TITLE
Bump poetry to 1.3.2

### DIFF
--- a/kevm-pyk/README.md
+++ b/kevm-pyk/README.md
@@ -3,7 +3,7 @@
 
 ## Installation
 
-Prerequsites: `python 3.8.*`, `pip >= 20.0.2`, `poetry >= 1.3.0`.
+Prerequsites: `python 3.8.*`, `pip >= 20.0.2`, `poetry >= 1.3.2`.
 
 ```bash
 make build


### PR DESCRIPTION
Encountered the error `relative path can't be expressed as a file URI` when running `make poetry`.
I've updated the poetry version to `1.3.2`, which [fixes an issue where passing a relative path via -C, --directory fails](https://github.com/python-poetry/poetry/releases/tag/1.3.2).

I've updated the poetry version to `1.3.2` in the readme file.
