### PR TITLE
Initial commit to AlgoEVM

### DIFF
--- a/include/kframework/driver.md
+++ b/include/kframework/driver.md
@@ -382,7 +382,8 @@ Note that `TEST` is sorted here so that key `"network"` comes before key `"pre"`
     rule <k> check "account" : { (_ACCT:Int) : { "balance" : ((VAL:String)      => #parseWord(VAL)) } }        ... </k>
     rule <k> check "account" : { (_ACCT:Int) : { "nonce"   : ((VAL:String)      => #parseWord(VAL)) } }        ... </k>
     rule <k> check "account" : { (_ACCT:Int) : { "code"    : ((CODE:String)     => #parseByteStack(CODE)) } }  ... </k>
-    rule <k> check "account" : { (_ACCT:Int) : { "storage" : ({ STORAGE:JSONs } => #parseMap({ STORAGE })) } } ... </k>
+    rule <k> check "account" : 
+      { (_ACCT:Int) : { "storage" : ({ STORAGE:JSONs } => #parseMap({ STORAGE })) } } ... </k>
 
     rule <mode> EXECMODE </mode>
          <k> check "account" : { ACCT : { "balance" : (BAL:Int) } } => . ... </k>
@@ -402,10 +403,10 @@ Note that `TEST` is sorted here so that key `"network"` comes before key `"pre"`
            <nonce> NONCE </nonce>
            ...
          </account>
-
-    rule <k> check "account" : { ACCT : { "storage" : (STORAGE:Map) } } => . ... </k>
+    
+    rule <k> check "account" : { ACCT : { "storage" : STORAGE } } => . ... </k>
          <account>
-           <acctID> ACCT </acctID>
+          <acctID> ACCT </acctID>
            <storage> ACCTSTORAGE </storage>
            ...
          </account>

--- a/include/kframework/evm-types.md
+++ b/include/kframework/evm-types.md
@@ -7,13 +7,31 @@ Both are implemented using K's `Int`.
 
 ```k
 requires "word.md"
+```
 
+> AlgoEVM
+
+```k
+module STORAGE
+    imports MAP
+    syntax Storage ::= Map | #write(Storage, Int, Int) [function]
+    rule #write(S:Map, I, V) => S [I <- V]
+endmodule
+```
+
+```k
 module EVM-TYPES
     imports STRING
     imports COLLECTIONS
     imports K-EQUAL
     imports JSON
     imports WORD
+```
+
+> AlgoEVM
+
+```k
+    imports STORAGE
 ```
 
 Utilities
@@ -520,9 +538,17 @@ Storage/Memory Lookup
 
 `#lookup*` looks up a key in a map and returns 0 if the key doesn't exist, otherwise returning its value.
 
-```k
     syntax Int ::= #lookup        ( Map , Int ) [function, total, smtlib(lookup)]
                  | #lookupMemory  ( Map , Int ) [function, total, smtlib(lookupMemory)]
+
+> ALgoEVM
+
+```k
+    syntax Int ::= #lookup        ( Storage , Int ) [function, total, smtlib(lookup)]
+                 | #lookupMemory  ( Storage , Int ) [function, total, smtlib(lookupMemory)]
+```
+
+```k
  // -----------------------------------------------------------------------------------
     rule [#lookup.some]:         #lookup(       (KEY |-> VAL:Int) _M, KEY ) => VAL modInt pow256
     rule [#lookup.none]:         #lookup(                          M, KEY ) => 0                 requires notBool KEY in_keys(M)

--- a/include/kframework/evm.md
+++ b/include/kframework/evm.md
@@ -130,8 +130,19 @@ In the comments next to each cell, we've marked which component of the YellowPap
                 <acctID>      0                      </acctID>
                 <balance>     0                      </balance>
                 <code>        .ByteArray:AccountCode </code>
+```
+
+> AlgoEVM
+
                 <storage>     .Map                   </storage>
                 <origStorage> .Map                   </origStorage>
+
+```k
+                <storage>     (.Map):Storage         </storage>
+                <origStorage> (.Map):Storage         </origStorage>
+```
+
+```k
                 <nonce>       0                      </nonce>
               </account>
             </accounts>
@@ -1251,13 +1262,27 @@ These rules reach into the network state and load/store from account storage:
 
     syntax BinStackOp ::= "SSTORE"
  // ------------------------------
+
     rule <k> SSTORE INDEX NEW => . ... </k>
          <id> ACCT </id>
          <account>
            <acctID> ACCT </acctID>
-           <storage> STORAGE => STORAGE [ INDEX <- NEW ] </storage>
+           <storage> STORAGE => STORAGE [INDEX <- NEW] </storage> 
            ...
-         </account>
+         </account> [priority(20)]
+
+```
+
+> AlgoEVM
+
+```k
+    rule <k> SSTORE INDEX NEW => . ... </k>
+         <id> ACCT </id>
+         <account>
+           <acctID> ACCT </acctID>
+           <storage> STORAGE => #write(STORAGE, INDEX, NEW) </storage> 
+           ...
+         </account> [priority(40)]
 ```
 
 ### Call Operations

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -5,3 +5,4 @@ tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
 tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
 tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
 tests/specs/opcodes/create-spec.k
+tests/specs/functional/lemmas-spec.k

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -1,11 +1,18 @@
 requires "edsl.md"
 requires "lemmas/lemmas.k"
+requires "evm-types.md"
 
 module VERIFICATION
     imports EDSL
     imports LEMMAS
+    imports STORAGE
 
-    syntax StepSort ::= Map | ByteArray | Int | Bool
+// ALGOEVM
+// -------
+
+    syntax StepSort ::= Storage | ByteArray | Int | Bool
+
+ //    syntax StepSort ::= Map | ByteArray | Int | Bool
  // ------------------------------------------------
 
     syntax KItem ::= runLemma ( StepSort )
@@ -96,7 +103,6 @@ module LEMMAS-SPEC
     claim <k> runLemma ( #lookup((_KEY |-> 33) (_KEY' |-> 728) ( KEY'' |-> (pow256 +Int 5)) (_KEY''' |-> "hello"), KEY'')  ) => doneLemma ( 5   ) ... </k>
     claim <k> runLemma ( #lookup((_KEY |-> 33) (_KEY' |-> 728) (_KEY'' |-> (pow256 +Int 5)) ( KEY''' |-> "hello"), KEY''') ) => doneLemma ( 0   ) ... </k>
     //claim <k> runLemma ( #lookup((KEY |-> 33), KEY') ) => doneLemma ( 0 ) ... </k> requires notBool KEY' in_keys(KEY |-> 33)
-
     claim <k> runLemma ( #lookup( _M:Map [ KEY <- 33 ] [ KEY' <- 728 ] [ KEY'' <- (pow256 +Int 5) ] [ KEY''' <- "hello" ] , KEY    ) ) => doneLemma ( 33  ) ... </k> requires KEY =/=Int KEY' andBool KEY =/=Int KEY'' andBool KEY =/=Int KEY''' andBool KEY' =/=Int KEY'' andBool KEY' =/=Int KEY''' andBool KEY'' =/=Int KEY'''
     claim <k> runLemma ( #lookup( _M:Map [ KEY <- 33 ] [ KEY' <- 728 ] [ KEY'' <- (pow256 +Int 5) ] [ KEY''' <- "hello" ] , KEY'   ) ) => doneLemma ( 728 ) ... </k> requires KEY =/=Int KEY' andBool KEY =/=Int KEY'' andBool KEY =/=Int KEY''' andBool KEY' =/=Int KEY'' andBool KEY' =/=Int KEY''' andBool KEY'' =/=Int KEY'''
     // claim <k> runLemma ( #lookup( _M:Map [ KEY <- 33 ] [ KEY' <- 728 ] [ KEY'' <- (pow256 +Int 5) ] [ KEY''' <- "hello" ] , KEY''  ) ) => doneLemma ( 5   ) ... </k> requires KEY =/=Int KEY' andBool KEY =/=Int KEY'' andBool KEY =/=Int KEY''' andBool KEY' =/=Int KEY'' andBool KEY' =/=Int KEY''' andBool KEY'' =/=Int KEY'''


### PR DESCRIPTION
- Add `Storage` as supersort of `Map` and function `write`.
  + Write simply behaves as Map in this commit.
- Changed semantics of `SLOAD` and `SSTORE` to cope with `Storage`.
- Changed signature of `#lookup` to cope with `Storage`.