### PR TITLE
Split kore-rpc-command string into words if given

### DIFF
--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -382,6 +382,10 @@ def exec_foundry_prove(
     _ignore_arg(kwargs, 'syntax_module', f'--syntax-module: {kwargs["syntax_module"]}')
     _ignore_arg(kwargs, 'definition_dir', f'--definition: {kwargs["definition_dir"]}')
     _ignore_arg(kwargs, 'spec_module', f'--spec-module: {kwargs["spec_module"]}')
+
+    if isinstance(kore_rpc_command, str):
+        kore_rpc_command = kore_rpc_command.split()
+
     results = foundry_prove(
         foundry_out=foundry_out,
         max_depth=max_depth,


### PR DESCRIPTION
This fixes the `--kore-rpc-command` option for cases where the command is not a single string, for example `--kore-rpc-command="kore-rpc --log-level info --log myfile.log"` 