### PR TITLE
Refactor test-foundry make command

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -135,8 +135,12 @@ jobs:
         run: docker exec -u user kevm-ci-foundry-${GITHUB_SHA} /bin/bash -c 'make kevm-pyk'
       - name: 'Build Foundry'
         run: docker exec -u user kevm-ci-foundry-${GITHUB_SHA} /bin/bash -c 'make build-foundry -j2'
-      - name: 'Test Foundry'
-        run: docker exec -u user kevm-ci-foundry-${GITHUB_SHA} /bin/bash -c 'make test-foundry -j2 FOUNDRY_PAR=12'
+      - name: 'Foundry Kompile'
+        run: docker exec -u user kevm-ci-foundry-${GITHUB_SHA} /bin/bash -c 'make test-foundry-kompile -j2'
+      - name: 'Foundry Prove'
+        run: docker exec -u user kevm-ci-foundry-${GITHUB_SHA} /bin/bash -c 'make test-foundry-prove -j2 FOUNDRY_PAR=12'
+      - name: 'Foundry List'
+        run: docker exec -u user kevm-ci-foundry-${GITHUB_SHA} /bin/bash -c 'make test-foundry-list -j2'
       - name: 'Tear down Docker'
         if: always()
         run: |

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ export PLUGIN_FULL_PATH
         test-prove test-failing-prove                                                                                                        \
         test-prove-benchmarks test-prove-functional test-prove-opcodes test-prove-erc20 test-prove-bihu test-prove-examples test-prove-smoke \
         test-prove-mcd test-klab-prove                                                                                                       \
-        test-parse test-failure test-foundry test-foundry-forge                                                                              \
+        test-parse test-failure test-foundry-kompile test-foundry-prove test-foundry-list                                                    \
         test-interactive test-interactive-help test-interactive-run test-interactive-prove test-interactive-search                           \
         test-kevm-pyk foundry-forge-build foundry-forge-test foundry-clean                                                                   \
         media media-pdf metropolis-theme                                                                                                     \
@@ -486,9 +486,11 @@ tests/foundry/%: KEVM = $(POETRY_RUN) kevm
 foundry_dir  := tests/foundry
 foundry_out := $(foundry_dir)/out
 
-test-foundry: KEVM_OPTS += --pyk --verbose
-test-foundry: KEVM = $(POETRY_RUN) kevm
-test-foundry: tests/foundry/foundry.k.check tests/foundry/out/kompiled/foundry.k.prove
+test-foundry-%: KEVM_OPTS += --pyk --verbose
+test-foundry-%: KEVM = $(POETRY_RUN) kevm
+test-foundry-kompile: tests/foundry/foundry.k.check
+test-foundry-prove: tests/foundry/out/kompiled/foundry.k.prove
+test-foundry-list: tests/foundry/foundry-list.check
 
 foundry-forge-build: $(foundry_out)
 
@@ -498,6 +500,13 @@ foundry-forge-test: foundry-forge-build
 $(foundry_out):
 	rm -rf $@
 	cd $(dir $@) && forge build
+
+tests/foundry/foundry-list.out: tests/foundry/out/kompiled/foundry.k
+	$(KEVM) foundry-list --foundry-project-root $(foundry_dir) > $@
+
+tests/foundry/foundry-list.check: tests/foundry/foundry-list.out
+	grep --invert-match 'path:' $< > $@.stripped
+	$(CHECK) $@.stripped $@.expected
 
 tests/foundry/foundry.k.check: tests/foundry/out/kompiled/foundry.k
 	grep --invert-match '    rule  ( #binRuntime (' $< > $@.stripped

--- a/tests/foundry/foundry-list.check.expected
+++ b/tests/foundry/foundry-list.check.expected
@@ -1,0 +1,319 @@
+PlainPrankTest.test_prank_zeroAddress_true: passed
+    nodes: 26
+    frontier: 0
+    stuck: 0
+
+AccountParamsTest.testNonceSymbolic: passed
+    nodes: 8
+    frontier: 0
+    stuck: 0
+
+PlainPrankTest.test_startPrankWithOrigin_true: passed
+    nodes: 20
+    frontier: 0
+    stuck: 0
+
+StoreTest.testGasLoadColdVM: passed
+    nodes: 8
+    frontier: 0
+    stuck: 0
+
+AccountParamsTest.test_Nonce_NonExistentAddress: passed
+    nodes: 9
+    frontier: 0
+    stuck: 0
+
+ExpectRevertTest.testFail_ExpectRevert_failAndSuccess: passed
+    nodes: 15
+    frontier: 0
+    stuck: 0
+
+AccountParamsTest.test_GetNonce_true: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+ExpectRevertTest.test_expectRevert_returnValue: passed
+    nodes: 16
+    frontier: 0
+    stuck: 0
+
+AccountParamsTest.test_Nonce_ExistentAddress: passed
+    nodes: 6
+    frontier: 0
+    stuck: 0
+
+ArithmeticTest.test_max2: passed
+    nodes: 9
+    frontier: 0
+    stuck: 0
+
+ExpectRevertTest.test_expectRevert_internalCall: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+LabelTest.testLabel: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+ExpectRevertTest.test_ExpectRevert_increasedDepth: passed
+    nodes: 25
+    frontier: 0
+    stuck: 0
+
+StoreTest.testGasStoreColdVM: passed
+    nodes: 8
+    frontier: 0
+    stuck: 0
+
+AssumeTest.test_assume_staticCall: passed
+    nodes: 6
+    frontier: 0
+    stuck: 0
+
+SymbolicStorageTest.testFail_SymbolicStorage1: passed
+    nodes: 20
+    frontier: 0
+    stuck: 0
+
+LoopsTest.test_sum_10: passed
+    nodes: 8
+    frontier: 0
+    stuck: 0
+
+AddrTest.test_builtInAddresses: passed
+    nodes: 4
+    frontier: 0
+    stuck: 0
+
+StoreTest.testStoreLoadNonExistent: passed
+    nodes: 9
+    frontier: 0
+    stuck: 0
+
+BlockParamsTest.testRoll: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+AddrTest.test_notBuiltinAddress_symbolic: passed
+    nodes: 7
+    frontier: 0
+    stuck: 0
+
+AssertTest.test_assert_true_branch: passed
+    nodes: 9
+    frontier: 0
+    stuck: 0
+
+AllowChangesTest.testFailAllowChangesToStorage: passed
+    nodes: 25
+    frontier: 0
+    stuck: 0
+
+BytesTypeTest.test_bytes32: passed
+    nodes: 4
+    frontier: 0
+    stuck: 0
+
+StoreTest.testGasStoreWarmUp: passed
+    nodes: 12
+    frontier: 0
+    stuck: 0
+
+StoreTest.testStoreLoad: passed
+    nodes: 12
+    frontier: 0
+    stuck: 0
+
+AccountParamsTest.testEtchConcrete: passed
+    nodes: 23
+    frontier: 0
+    stuck: 0
+
+BlockParamsTest.testChainId: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+CounterTest.testIncrement: passed
+    nodes: 23
+    frontier: 0
+    stuck: 0
+
+AccountParamsTest.testFail_GetNonce_true: passed
+    nodes: 12
+    frontier: 0
+    stuck: 0
+
+AccountParamsTest.testDealConcrete: passed
+    nodes: 8
+    frontier: 0
+    stuck: 0
+
+AssumeTest.test_assume_true: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+BlockParamsTest.testWarp: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+UintTypeTest.test_uint256: passed
+    nodes: 4
+    frontier: 0
+    stuck: 0
+
+ExpectCallTest.testExpectStaticCall: passed
+    nodes: 16
+    frontier: 0
+    stuck: 0
+
+AssertTest.test_assert_true: passed
+    nodes: 4
+    frontier: 0
+    stuck: 0
+
+PlainPrankTest.testFail_startPrank_internalCall: passed
+    nodes: 9
+    frontier: 0
+    stuck: 0
+
+BlockParamsTest.testFee: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+StoreTest.testGasLoadWarmUp: passed
+    nodes: 12
+    frontier: 0
+    stuck: 0
+
+AssumeTest.test_multi_assume: passed
+    nodes: 13
+    frontier: 0
+    stuck: 0
+
+SymbolicStorageTest.testFail_SymbolicStorage: passed
+    nodes: 17
+    frontier: 0
+    stuck: 0
+
+ExpectRevertTest.testFail_expectRevert_empty: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+AccountParamsTest.testDealSymbolic: passed
+    nodes: 8
+    frontier: 0
+    stuck: 0
+
+ExpectRevertTest.test_expectRevert_true: passed
+    nodes: 15
+    frontier: 0
+    stuck: 0
+
+BlockParamsTest.testCoinBase: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+ExpectRevertTest.testFail_expectRevert_false: passed
+    nodes: 15
+    frontier: 0
+    stuck: 0
+
+AllowChangesTest.testFailAllowCallsToAddress: passed
+    nodes: 25
+    frontier: 0
+    stuck: 0
+
+AddrTest.test_notBuiltinAddress_concrete: passed
+    nodes: 4
+    frontier: 0
+    stuck: 0
+
+StoreTest.testLoadNonExistent: passed
+    nodes: 8
+    frontier: 0
+    stuck: 0
+
+GasTest.testInfiniteGas: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+PlainPrankTest.test_stopPrank_notExistent: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+AllowChangesTest.testAllow: passed
+    nodes: 25
+    frontier: 0
+    stuck: 0
+
+PlainPrankTest.test_startPrank_zeroAddress_true: passed
+    nodes: 23
+    frontier: 0
+    stuck: 0
+
+EmitContractTest.testExpectEmitDoNotCheckData: passed
+    nodes: 15
+    frontier: 0
+    stuck: 0
+
+ExpectRevertTest.testFail_expectRevert_multipleReverts: passed
+    nodes: 19
+    frontier: 0
+    stuck: 0
+
+BytesTypeTest.test_bytes4: passed
+    nodes: 4
+    frontier: 0
+    stuck: 0
+
+SymbolicStorageTest.testEmptyInitialStorage: passed
+    nodes: 5
+    frontier: 0
+    stuck: 0
+
+EmitContractTest.testExpectEmit: passed
+    nodes: 15
+    frontier: 0
+    stuck: 0
+
+EmitContractTest.testExpectEmitCheckEmitter: passed
+    nodes: 15
+    frontier: 0
+    stuck: 0
+
+PlainPrankTest.test_startPrank_true: passed
+    nodes: 20
+    frontier: 0
+    stuck: 0
+
+ExpectCallTest.testExpectRegularCall: passed
+    nodes: 16
+    frontier: 0
+    stuck: 0
+
+ArithmeticTest.test_max1: passed
+    nodes: 10
+    frontier: 0
+    stuck: 0
+
+CounterTest.testSetNumber: passed
+    nodes: 23
+    frontier: 0
+    stuck: 0
+
+ExpectRevertTest.test_expectRevert_message: passed
+    nodes: 17
+    frontier: 0
+    stuck: 0


### PR DESCRIPTION
- added a check for `kevm foundry-list` to catch bugs like #1701.
- split `test-foundry` make command in : 
     -  `test-foundry-kompile` -  checks `foundry.k` file.
     -  `test-foundry-prove` - executes the proofs.
     -  `test-foundry-list` - runs `kevm foundry-list` and compares the output to an expected file in order to test the parsing of the KCFGs.