### PR TITLE
Mark various functions as total

### DIFF
--- a/include/kframework/evm.md
+++ b/include/kframework/evm.md
@@ -1690,8 +1690,8 @@ Precompiled Contracts
          <callData> DATA </callData>
          <output> _ => #ecrec(#range(DATA, 0, 32), #range(DATA, 32, 32), #range(DATA, 64, 32), #range(DATA, 96, 32)) </output>
 
-    syntax Bytes ::= #ecrec ( Bytes , Bytes , Bytes , Bytes ) [function, smtlib(ecrec)]
-                   | #ecrec ( Account )                       [function]
+    syntax Bytes ::= #ecrec ( Bytes , Bytes , Bytes , Bytes ) [function, total, smtlib(ecrec)]
+                   | #ecrec ( Account )                       [function, total]
  // --------------------------------------------------------------------
     rule [ecrec]: #ecrec(HASH, SIGV, SIGR, SIGS) => #ecrec(#sender(#unparseByteStack(HASH), #asWord(SIGV), #unparseByteStack(SIGR), #unparseByteStack(SIGS)))
 

--- a/include/kframework/foundry.md
+++ b/include/kframework/foundry.md
@@ -1319,7 +1319,7 @@ If the production is matched when no prank is active, it will be ignored.
         </prank>
 ```
 ```k
-    syntax Bytes ::= #sign ( Bytes , Bytes ) [function,klabel(foundry_sign)]
+    syntax Bytes ::= #sign ( Bytes , Bytes ) [function, total, klabel(foundry_sign)]
  // ------------------------------------------------------------------------
     rule #sign(BA1, BA2) => #parseByteStack(ECDSASign(#unparseByteStack(BA1), #unparseByteStack(BA2))) [concrete]
 ```


### PR DESCRIPTION
This PR marks the `#ecrec` and the `#sign` functions as `total`, as they were triggering spurious definedness checks. I think (at least morally) it makes sense to mark them as total.