### PR TITLE
Initialize `KCFGExplore` with LLVM kompiled directory if it exists

### DIFF
--- a/kevm-pyk/src/kevm_pyk/__main__.py
+++ b/kevm-pyk/src/kevm_pyk/__main__.py
@@ -13,6 +13,7 @@ from pyk.cterm import CTerm
 from pyk.kast.outer import KApply, KRewrite
 from pyk.kcfg import KCFG, KCFGExplore
 from pyk.kore.prelude import int_dv
+from pyk.ktool.kompile import LLVMKompileType
 from pyk.ktool.krun import KRunOutput, _krun
 from pyk.prelude.ml import is_bottom, is_top
 from pyk.proof import APRProof
@@ -103,6 +104,7 @@ def exec_kompile(
     o3: bool = False,
     debug: bool = False,
     enable_llvm_debug: bool = False,
+    llvm_library: bool = False,
     **kwargs: Any,
 ) -> None:
     optimization = 0
@@ -125,6 +127,7 @@ def exec_kompile(
         ccopts=ccopts,
         optimization=optimization,
         enable_llvm_debug=enable_llvm_debug,
+        llvm_kompile_type=LLVMKompileType.C if llvm_library else LLVMKompileType.MAIN,
         debug=debug,
     )
 

--- a/kevm-pyk/src/kevm_pyk/foundry.py
+++ b/kevm-pyk/src/kevm_pyk/foundry.py
@@ -443,6 +443,7 @@ def foundry_prove(
     save_directory = foundry.out / 'apr_proofs'
     save_directory.mkdir(exist_ok=True)
 
+    foundry_llvm_dir = None
     if use_booster:
         try:
             run_process(('which', 'kore-rpc-booster'), pipe_stderr=True).stdout.strip()
@@ -451,10 +452,10 @@ def foundry_prove(
                 "Couldn't locate the kore-rpc-booster RPC binary. Please put 'kore-rpc-booster' on PATH manually or using kup install/kup shell."
             ) from None
 
+        foundry_llvm_dir = foundry.out / 'kompiled-llvm'
         if foundry.llvm_dylib:
-            kore_rpc_command = ('kore-rpc-booster', '--llvm-backend-library', str(foundry.llvm_dylib))
+            kore_rpc_command = 'kore-rpc-booster'
         else:
-            foundry_llvm_dir = foundry.out / 'kompiled-llvm'
             raise ValueError(
                 f"Could not find the LLVM dynamic library in {foundry_llvm_dir}. Please re-run foundry-kompile with the '--with-llvm-library' flag"
             )
@@ -518,6 +519,7 @@ def foundry_prove(
         proof_id = f'{_init_problem[0]}.{_init_problem[1]}'
         with KCFGExplore(
             foundry.kevm,
+            llvm_definition_dir=foundry_llvm_dir,
             id=proof_id,
             bug_report=br,
             kore_rpc_command=kore_rpc_command,


### PR DESCRIPTION
This PR is a follow-up to a recent update in `pyk` (https://github.com/runtimeverification/pyk/pull/514) that abstracted the use of `kore-rpc-booster` into `BoosterServer` class.  The changes in this PR make sure that `KCFGExplore` is initialized in the newly prescribed way.  