### PR TITLE
Rename `--id` to `--version` in the error message

### DIFF
--- a/kevm-pyk/src/kontrolx/foundry.py
+++ b/kevm-pyk/src/kontrolx/foundry.py
@@ -306,7 +306,7 @@ class Foundry:
         if id is None:
             if len(matching_proofs) > 1:
                 raise ValueError(
-                    f'Found {len(matching_proofs)} matching proofs for {test}. Use the --id flag to choose one.'
+                    f'Found {len(matching_proofs)} matching proofs for {test}. Use the --version flag to choose one.'
                 )
             test_id = single(matching_proofs).id
             return test_id


### PR DESCRIPTION
Follow up to https://github.com/runtimeverification/evm-semantics/pull/2064.

The error message shown by `foundry-view-kcfg` and `foundry-show` if multiple proofs are present should suggest to specify `--version`, not `--id`, as it was renamed in https://github.com/runtimeverification/evm-semantics/pull/2064.