### PR TITLE
chore(kevm-pyk/src): typo fix

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
@@ -61,7 +61,7 @@ Word Operations
 
 -   `up/Int` performs integer division but rounds up instead of down.
 
-NOTE: Here, we choose to add `I2 -Int 1` to the numerator beforing doing the division to mimic the C++ implementation.
+NOTE: Here, we choose to add `I2 -Int 1` to the numerator before doing the division to mimic the C++ implementation.
 You could alternatively calculate `I1 modInt I2`, then add one to the normal integer division afterward depending on the result.
 
 ```k

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -1985,7 +1985,7 @@ Execution Gas
 
 The intrinsic gas calculation mirrors the style of the YellowPaper (appendix H).
 
--   `#gasExec` loads all the relevant surronding state and uses that to compute the intrinsic execution gas of each opcode.
+-   `#gasExec` loads all the relevant surrounding state and uses that to compute the intrinsic execution gas of each opcode.
 
 ```k
     syntax InternalOp ::= #gasExec ( Schedule , OpCode )

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -729,7 +729,7 @@ These are just used by the other operators for shuffling local execution state a
     rule <k> #setStack WS    => . ... </k> <wordStack> _  => WS      </wordStack>
 ```
 
--   `#newAccount_` allows declaring a new empty account with the given address (and assumes the rounding to 160 bits has already occured).
+-   `#newAccount_` allows declaring a new empty account with the given address (and assumes the rounding to 160 bits has already occurred).
     If the account already exists with non-zero nonce or non-empty code, an exception is thrown.
     Otherwise, if the account already exists, the storage is cleared.
 
@@ -1213,7 +1213,7 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
 -   `#checkDepthExceeded` checks if the current call depth is greater than or equal to `1024`.
 -   `#checkNonceExceeded` takes the calling account and checks if the nonce is less than `maxUInt64` (`18446744073709551615`).
 -   `#call` takes the calling account, the account to execute as, the account whose code should execute, the gas limit, the amount to transfer, the arguments, and the static flag.
--   `#callWithCode` takes the calling account, the accout to execute as, the code to execute (as a `Bytes`), the gas limit, the amount to transfer, the arguments, and the static flag.
+-   `#callWithCode` takes the calling account, the account to execute as, the code to execute (as a `Bytes`), the gas limit, the amount to transfer, the arguments, and the static flag.
 -   `#return` is a placeholder for the calling program, specifying where to place the returned data in memory.
 
 ```k

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/issues.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/issues.md
@@ -57,7 +57,7 @@ These can be issues from simple "why did they do it that way?" to "this makes do
 -   Program representation is important in EVM (that is, you must be able to represent a program as a byte-array of opcodes).
     When doing program analysis/abstract verification, you ideally would be allowed to make transformations on the program representation (e.g., convert it to a control-flow graph) without having to maintain a translation back.
     Currently in EVM, the `*CODECOPY` opcodes allow regarding program pieces as data, meaning that a translation back must always be maintained, because using `CREATE` with `DELEGATECALL` allows executing arbitrary code.
-    For this reason, we had to build a parser/unparser and an assembler/dissasembler into our semantics.
+    For this reason, we had to build a parser/unparser and an assembler/disassembler into our semantics.
     Putting a symbolic value through the process of disassembling -> unparsing loses a lot of semantic information about the original value.
     While self-modifying code is nice and powerful in principle, we are not aware of any programming languages for the blockchain that encourage or even allow that.
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/network.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/network.md
@@ -27,7 +27,7 @@ The following codes all indicate that the VM ended execution with an exception, 
 -   `EVMC_STACK_OVERFLOW` indicates pushing more than 1024 elements onto the wordstack.
 -   `EVMC_STACK_UNDERFLOW` indicates popping elements off an empty wordstack.
 -   `EVMC_CALL_DEPTH_EXCEEDED` indicates that we have executed too deeply a nested sequence of `CALL*` or `CREATE` opcodes.
--   `EVMC_INVALID_MEMORY_ACCESS` indicates that a bad memory access occured.
+-   `EVMC_INVALID_MEMORY_ACCESS` indicates that a bad memory access occurred.
     This can happen when accessing local memory with `CODECOPY*` or `CALLDATACOPY`, or when accessing return data with `RETURNDATACOPY`.
 -   `EVMC_STATIC_MODE_VIOLATION` indicates that a `STATICCALL` tried to change state.
     **TODO:** Avoid `_ERROR` suffix that suggests fatal error.

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/word.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/word.md
@@ -14,7 +14,7 @@ Important Powers
 ----------------
 
 Some important numbers that are referred to often during execution.
-These can be used for pattern-matching on the LHS of rules as well (`alias` attribute expands all occurances of these in rules).
+These can be used for pattern-matching on the LHS of rules as well (`alias` attribute expands all occurrences of these in rules).
 
 ```k
     syntax Int ::= "pow5"   [macro] /* 2 ^Int 5   */


### PR DESCRIPTION
Hey, found a few typos in the docs, hope it helps
Doesn't need any testing/changelog entry.