### PR TITLE
use system libsecp256k1

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kdist/plugin.py
+++ b/kevm-pyk/src/kevm_pyk/kdist/plugin.py
@@ -65,13 +65,12 @@ class PluginTarget(Target):
 
         copy_tree(str(config.PLUGIN_DIR), '.')
         run_process(
-            ['make', 'libcryptopp', 'libff', 'libsecp256k1', '-j3'],
+            ['make', 'libcryptopp', 'libff', '-j8'],
             pipe_stdout=not verbose,
         )
 
         copy_tree('./build/libcryptopp', str(output_dir / 'libcryptopp'))
         copy_tree('./build/libff', str(output_dir / 'libff'))
-        copy_tree('./build/libsecp256k1', str(output_dir / 'libsecp256k1'))
 
     def source(self) -> tuple[Path]:
         return (config.PLUGIN_DIR,)

--- a/kevm-pyk/src/kevm_pyk/kompile.py
+++ b/kevm-pyk/src/kevm_pyk/kompile.py
@@ -211,16 +211,13 @@ def lib_ccopts(plugin_dir: Path, debug_build: bool = False) -> list[str]:
     if debug_build:
         ccopts += ['-g']
 
-    ccopts += ['-lssl', '-lcrypto']
+    ccopts += ['-lssl', '-lcrypto', '-lsecp256k1']
 
     libff_dir = plugin_dir / 'libff'
     ccopts += [f'{libff_dir}/lib/libff.a', f'-I{libff_dir}/include']
 
     libcryptopp_dir = plugin_dir / 'libcryptopp'
     ccopts += [f'{libcryptopp_dir}/lib/libcryptopp.a', f'-I{libcryptopp_dir}/include']
-
-    libsecp256k1_dir = plugin_dir / 'libsecp256k1'
-    ccopts += [f'{libsecp256k1_dir}/lib/libsecp256k1.a', f'-I{libsecp256k1_dir}/include']
 
     plugin_include = plugin_dir / 'plugin-c'
     ccopts += [


### PR DESCRIPTION
This is a test to see whether or not we can get a working version of KEVM with the system installed library of libsecp256k1. Still a draft and may be closed if this does not end up working out.