### PR TITLE
Update link from unofficial nixos wiki to official one

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Always have your build up-to-date.
 
 ### Building with Nix
 
-We now support building KEVM using [nix flakes](https://nixos.wiki/wiki/Flakes).
+We now support building KEVM using [nix flakes](https://wiki.nixos.org/wiki/Flakes).
 To set up nix flakes you will need to be on `nix` 2.4 or higher and follow the instructions [here](https://nixos.wiki/wiki/Flakes).
 
 For example, if you are on a standard Linux distribution, such as Ubuntu, first [install nix](https://nixos.org/download.html#download-nix)


### PR DESCRIPTION
The README references the old, unofficial NixOS wiki. This PR updates the links to point to the new official NixOS wiki source, which will be more properly maintained in the future. It's very much a Fandom wiki situation.