### PR TITLE
Add option string for symbolic-immutables

### DIFF
--- a/kevm-pyk/src/kevm_pyk/cli.py
+++ b/kevm-pyk/src/kevm_pyk/cli.py
@@ -367,6 +367,7 @@ class ExploreOptions(Options):
     @staticmethod
     def from_option_string() -> dict[str, str]:
         return {
+            'symbolic-immutables': 'break_on_load_program',
             'failure-information': 'failure_info',
             'no-failure-information': 'no_failure_info',
         }


### PR DESCRIPTION
Closes: https://github.com/runtimeverification/kontrol/issues/776

Adding a missing option string that was causing `symbolic-immutables` flag in the kontrol.toml file to be parsed to `symbolic_immutables` instead of `break_on_load_program`.