### PR TITLE
Fix typo and add missing precompile descriptions to evm.md

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -1818,7 +1818,7 @@ Precompiled Contracts
 ```
 
 -   `ECREC` performs ECDSA public key recovery.
--   `SHA256` performs the SHA2-257 hash function.
+-   `SHA256` performs the SHA2-256 hash function.
 -   `RIP160` performs the RIPEMD-160 hash function.
 -   `ID` is the identity function (copies input to output).
 

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -1821,6 +1821,11 @@ Precompiled Contracts
 -   `SHA256` performs the SHA2-256 hash function.
 -   `RIP160` performs the RIPEMD-160 hash function.
 -   `ID` is the identity function (copies input to output).
+-   `MODEXP` performs arbitrary-precision modular exponentiation.
+-   `ECADD`  performs point addition on the elliptic curve alt_bn128.
+-   `ECMUL` performs scalar multiplication on the elliptic curve alt_bn128.
+-   `ECPAIRING` performs an optimal ate pairing check on the elliptic curve alt_bn128.
+-   `BLAKE2F` performs the compression function F used in the BLAKE2 hashing algorithm.
 
 ```k
     syntax PrecompiledOp ::= "ECREC"


### PR DESCRIPTION
Just some minor modification to the evm.md file for completeness.

- Fix a typo (SHA2-257 -> SHA2-256)
- Add missing descriptions of precompiles (modexp, ecadd, ecmul, ecpairing, blake2f) in line with the pre-existing ones.