### PR TITLE
Remove default `maintenance_rate` at `argparse` level

### DIFF
--- a/kevm-pyk/src/kevm_pyk/cli.py
+++ b/kevm-pyk/src/kevm_pyk/cli.py
@@ -838,7 +838,6 @@ class KEVMCLIArgs(KCLIArgs):
         args.add_argument(
             '--maintenance-rate',
             dest='maintenance_rate',
-            default=1,
             type=int,
             help='The number of proof iterations performed between two writes to disk and status bar updates. Note that setting to >1 may result in work being discarded if proof is interrupted.',
         )


### PR DESCRIPTION
Closes https://github.com/runtimeverification/kontrol/issues/833.
Follow up to https://github.com/runtimeverification/pyk/pull/976.

This PR fixes an issue with `maintenance-rate` value set in `kontrol.toml` getting ignored. 

In line with https://github.com/runtimeverification/pyk/pull/976, default values are now defined in the `Options` class (`ProveOptions`, [in this case](https://github.com/runtimeverification/evm-semantics/blob/2fd049028450b0ad38eff3c90269db542ebda06c/kevm-pyk/src/kevm_pyk/cli.py#L389)). A default value set at the `argparse` level, if present, is being treated as a CLI-provided option that replaces the value set in `kontrol.toml`. 

This PR removes the argparse default value for `--maintenance-rate`.