### PR TITLE
Removing SMT lemmas

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
@@ -407,18 +407,12 @@ Storage/Memory Lookup
 `#lookup*` looks up a key in a map and returns 0 if the key doesn't exist, otherwise returning its value.
 
 ```k
-    syntax Int ::= #lookup ( Map , Int ) [symbol(lookup), function, total, smtlib(lookup)]
- // --------------------------------------------------------------------------------------
-
-    // #lookup when key is present in map
-    rule #lookup( M:Map, K:Int ) => #if isInt( M:Map [ K ] ) #then { M:Map [ K ] }:>Int modInt pow256 #else 0 #fi
-      requires K in_keys( M:Map )
-      [priority(20), preserves-definedness]
-
-    // #lookup when key is absent in map
-    rule #lookup( M:Map, K:Int ) => 0
-      requires notBool K in_keys( M:Map )
-      [priority(25), preserves-definedness]
+    syntax Int ::= #lookup        ( Map , Int ) [symbol(lookup), function, total, smtlib(lookup)]
+ // ---------------------------------------------------------------------------------------------
+    rule [#lookup.some]:   #lookup( (KEY |-> VAL:Int) _M, KEY ) => VAL modInt pow256
+    rule [#lookup.none]:   #lookup(                    M, KEY ) => 0                 requires notBool KEY in_keys(M)
+    //Impossible case, for completeness
+    rule [#lookup.notInt]: #lookup( (KEY |-> VAL    ) _M, KEY ) => 0                 requires notBool isInt(VAL)
 ```
 
 Substate Log

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
@@ -407,18 +407,18 @@ Storage/Memory Lookup
 `#lookup*` looks up a key in a map and returns 0 if the key doesn't exist, otherwise returning its value.
 
 ```k
-    syntax Int ::= #lookup        ( Map , Int ) [symbol(lookup), function, total, smtlib(lookup)]
-                 | #lookupMemory  ( Map , Int ) [symbol(lookupMemory), function, total, smtlib(lookupMemory)]
- // ---------------------------------------------------------------------------------------------------------
-    rule [#lookup.some]:         #lookup(       (KEY |-> VAL:Int) _M, KEY ) => VAL modInt pow256
-    rule [#lookup.none]:         #lookup(                          M, KEY ) => 0                 requires notBool KEY in_keys(M)
-    //Impossible case, for completeness
-    rule [#lookup.notInt]:       #lookup(       (KEY |-> VAL    ) _M, KEY ) => 0                 requires notBool isInt(VAL)
+    syntax Int ::= #lookup ( Map , Int ) [symbol(lookup), function, total, smtlib(lookup)]
+ // --------------------------------------------------------------------------------------
 
-    rule [#lookupMemory.some]:   #lookupMemory( (KEY |-> VAL:Int) _M, KEY ) => VAL modInt 256
-    rule [#lookupMemory.none]:   #lookupMemory(                    M, KEY ) => 0                 requires notBool KEY in_keys(M)
-    //Impossible case, for completeness
-    rule [#lookupMemory.notInt]: #lookupMemory( (KEY |-> VAL    ) _M, KEY ) => 0                 requires notBool isInt(VAL)
+    // #lookup when key is present in map
+    rule #lookup( M:Map, K:Int ) => #if isInt( M:Map [ K ] ) #then { M:Map [ K ] }:>Int modInt pow256 #else 0 #fi
+      requires K in_keys( M:Map )
+      [priority(20), preserves-definedness]
+
+    // #lookup when key is absent in map
+    rule #lookup( M:Map, K:Int ) => 0
+      requires notBool K in_keys( M:Map )
+      [priority(25), preserves-definedness]
 ```
 
 Substate Log

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/bytes-simplification.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/bytes-simplification.k
@@ -279,10 +279,7 @@ module BYTES-SIMPLIFICATION [symbolic]
 
     // #ecrec
 
-    rule lengthBytes ( #ecrec ( _ , _ , _ , _ ) ) <=Int 32 => true
-        [simplification, smt-lemma]
-
-    rule #asWord ( #ecrec ( _ , _ , _ , _ ) ) <Int pow160 => true
-        [simplification, smt-lemma]
+    rule lengthBytes ( #ecrec ( _ , _ , _ , _ ) ) <=Int X:Int => true requires     32 <=Int X [simplification]
+    rule     #asWord ( #ecrec ( _ , _ , _ , _ ) )  <Int X:Int => true requires pow160 <=Int X [simplification]
 
 endmodule

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/evm-int-simplification.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/evm-int-simplification.k
@@ -115,8 +115,10 @@ module EVM-INT-SIMPLIFICATION
     [simplification, preserves-definedness]
 
   // Comparison: `#asWord` is always in the range `[0, pow256)`
-  rule [asWord-lb]: 0 <=Int #asWord( _ )     => true [simplification, smt-lemma]
-  rule [asWord-ub]: #asWord( _ ) <Int pow256 => true [simplification, smt-lemma]
+  rule [asWord-lb-lt]:        X:Int  <Int #asWord( _ ) => true requires          X  <Int 0 [simplification]
+  rule [asWord-lb-le]:        X:Int <=Int #asWord( _ ) => true requires          X <=Int 0 [simplification]
+  rule [asWord-ub-lt]: #asWord( _ )  <Int X:Int        => true requires maxUInt256  <Int X [simplification]
+  rule [asWord-ub-lt]: #asWord( _ ) <=Int X:Int        => true requires maxUInt256 <=Int X [simplification]
 
   // Comparison: `#asWord(B)` is certainly less than something that does not fit into `lengthBytes(B)` bytes
   rule [asWord-lt]:  #asWord ( B )  <Int X:Int => true  requires   2 ^Int (8 *Int minInt(32, lengthBytes(B)))          <=Int X [simplification, preserves-definedness]
@@ -141,9 +143,12 @@ module EVM-INT-SIMPLIFICATION
   // chop
   // ###########################################################################
 
-    rule [chop-resolve]:     chop(I) => I requires #rangeUInt( 256 , I ) [simplification]
-    rule [chop-upper-bound]: 0 <=Int chop(_V)             => true        [simplification, smt-lemma]
-    rule [chop-lower-bound]:         chop(_V) <Int pow256 => true        [simplification, smt-lemma]
+    rule [chop-resolve]: chop(I) => I requires #rangeUInt( 256 , I ) [simplification]
+
+    rule [chop-ub-lt]: X:Int  <Int chop(_V)             => true requires          X  <Int 0 [simplification]
+    rule [chop-ub-le]: X:Int <=Int chop(_V)             => true requires          X <=Int 0 [simplification]
+    rule [chop-lb-lt]:             chop(_V)  <Int X:Int => true requires maxUInt256  <Int X [simplification]
+    rule [chop-lb-le]:             chop(_V) <=Int X:Int => true requires maxUInt256 <=Int X [simplification]
 
     rule [chop-add-left]:  chop ( chop ( X:Int ) +Int Y:Int ) => chop ( X +Int Y ) [simplification]
     rule [chop-add-right]: chop ( X:Int +Int chop ( Y:Int ) ) => chop ( X +Int Y ) [simplification]

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/evm-int-simplification.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/evm-int-simplification.k
@@ -145,10 +145,10 @@ module EVM-INT-SIMPLIFICATION
 
     rule [chop-resolve]: chop(I) => I requires #rangeUInt( 256 , I ) [simplification]
 
-    rule [chop-ub-lt]: X:Int  <Int chop(_V)             => true requires          X  <Int 0 [simplification]
-    rule [chop-ub-le]: X:Int <=Int chop(_V)             => true requires          X <=Int 0 [simplification]
-    rule [chop-lb-lt]:             chop(_V)  <Int X:Int => true requires maxUInt256  <Int X [simplification]
-    rule [chop-lb-le]:             chop(_V) <=Int X:Int => true requires maxUInt256 <=Int X [simplification]
+    rule [chop-ub-lt]:    X:Int  <Int chop(_V) => true requires          X  <Int 0 [simplification]
+    rule [chop-ub-le]:    X:Int <=Int chop(_V) => true requires          X <=Int 0 [simplification]
+    rule [chop-lb-lt]: chop(_V)  <Int X:Int    => true requires maxUInt256  <Int X [simplification]
+    rule [chop-lb-le]: chop(_V) <=Int X:Int    => true requires maxUInt256 <=Int X [simplification]
 
     rule [chop-add-left]:  chop ( chop ( X:Int ) +Int Y:Int ) => chop ( X +Int Y ) [simplification]
     rule [chop-add-right]: chop ( X:Int +Int chop ( Y:Int ) ) => chop ( X +Int Y ) [simplification]

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/evm-int-simplification.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/evm-int-simplification.k
@@ -118,7 +118,7 @@ module EVM-INT-SIMPLIFICATION
   rule [asWord-lb-lt]:        X:Int  <Int #asWord( _ ) => true requires          X  <Int 0 [simplification]
   rule [asWord-lb-le]:        X:Int <=Int #asWord( _ ) => true requires          X <=Int 0 [simplification]
   rule [asWord-ub-lt]: #asWord( _ )  <Int X:Int        => true requires maxUInt256  <Int X [simplification]
-  rule [asWord-ub-lt]: #asWord( _ ) <=Int X:Int        => true requires maxUInt256 <=Int X [simplification]
+  rule [asWord-ub-le]: #asWord( _ ) <=Int X:Int        => true requires maxUInt256 <=Int X [simplification]
 
   // Comparison: `#asWord(B)` is certainly less than something that does not fit into `lengthBytes(B)` bytes
   rule [asWord-lt]:  #asWord ( B )  <Int X:Int => true  requires   2 ^Int (8 *Int minInt(32, lengthBytes(B)))          <=Int X [simplification, preserves-definedness]

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
@@ -60,8 +60,10 @@ module LEMMAS-WITHOUT-SLOT-UPDATES [symbolic]
   // ########################
 
     // Range
-    rule [b2w-lb]: 0 <=Int bool2Word(_)         => true [simplification, smt-lemma]
-    rule [b2w-ub]:         bool2Word(_) <=Int 1 => true [simplification, smt-lemma]
+    rule [b2w-lb-lt]:        X:Int  <Int bool2Word(_) => true requires X  <Int 0 [simplification]
+    rule [b2w-lb-le]:        X:Int <=Int bool2Word(_) => true requires X <=Int 0 [simplification]
+    rule [b2w-ub-lt]: bool2Word(_)  <Int X:Int        => true requires 1  <Int X [simplification]
+    rule [b2w-ub-le]: bool2Word(_) <=Int X:Int        => true requires 1 <=Int X [simplification]
 
     // Relationship with equality
     rule [b2w-eq-zero]: bool2Word(B) ==Int 0 => notBool B [simplification(30), comm]
@@ -118,8 +120,10 @@ module LEMMAS-WITHOUT-SLOT-UPDATES [symbolic]
   // Map Reasoning
   // ########################
 
-    rule 0 <=Int #lookup( _M:Map , _ )             => true [simplification, smt-lemma]
-    rule         #lookup( _M:Map , _ ) <Int pow256 => true [simplification, smt-lemma]
+    rule [lookup-lb-lt]:                 X:Int  <Int #lookup( _M:Map , _ ) => true requires          X  <Int 0 [simplification]
+    rule [lookup-lb-le]:                 X:Int <=Int #lookup( _M:Map , _ ) => true requires          X <=Int 0 [simplification]
+    rule [lookup-ub-lt]: #lookup( _M:Map , _ )  <Int X:Int                 => true requires maxUInt256  <Int X [simplification]
+    rule [lookup-ub-le]: #lookup( _M:Map , _ ) <=Int X:Int                 => true requires maxUInt256 <=Int X [simplification]
 
     rule #lookup ( _M:Map [ K1 <- V1 ] , K2 )    => #lookup ( K1 |-> V1 , K1 ) requires K1 ==Int  K2 [simplification]
     rule #lookup (  M:Map [ K1 <- _  ] , K2 )    => #lookup ( M         , K2 ) requires notBool ( K1 ==Int K2 ) [simplification]

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
@@ -128,8 +128,8 @@ module LEMMAS-WITHOUT-SLOT-UPDATES [symbolic]
     rule ( M:Map [ K1 <- _ ] ):Map [ K2 ] => M:Map [ K2 ] requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
 
     // Symbolic membership of map concat
-    rule K1 in_keys( ( K2 -> _ ) _:Map ) => true          requires         K1 ==K K2 [simplification(45), preserves-definedness]
-    rule K1 in_keys( ( K2 -> _ ) M:Map ) => K1 in_keys(M) requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
+    rule K1 in_keys( ( K2 |-> _ ) _:Map ) => true          requires         K1 ==K K2 [simplification(45), preserves-definedness]
+    rule K1 in_keys( ( K2 |-> _ ) M:Map ) => K1 in_keys(M) requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
 
     // Symbolic membership of map update
     rule K1 in_keys( _:Map [ K2 <- _ ] ) => true          requires         K1 ==K K2 [simplification(45), preserves-definedness]

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
@@ -117,17 +117,19 @@ module LEMMAS-WITHOUT-SLOT-UPDATES [symbolic]
     rule         keccak( _ ) <Int pow256 => true [simplification]
 
   // ########################
-  // Map Reasoning
+  // Map and #lookup
   // ########################
 
-    rule [lookup-lb-lt]:                 X:Int  <Int #lookup( _M:Map , _ ) => true requires          X  <Int 0 [simplification]
-    rule [lookup-lb-le]:                 X:Int <=Int #lookup( _M:Map , _ ) => true requires          X <=Int 0 [simplification]
-    rule [lookup-ub-lt]: #lookup( _M:Map , _ )  <Int X:Int                 => true requires maxUInt256  <Int X [simplification]
-    rule [lookup-ub-le]: #lookup( _M:Map , _ ) <=Int X:Int                 => true requires maxUInt256 <=Int X [simplification]
+    rule [lookup-lb]:                    0 <=Int #lookup( _:Map , _ ) => true [simplification, smt-lemma]
+    rule [lookup-up]: #lookup( _:Map , _ )  <Int pow256               => true [simplification, smt-lemma]
 
-    rule #lookup ( _M:Map [ K1 <- V1 ] , K2 )    => #lookup ( K1 |-> V1 , K1 ) requires K1 ==Int  K2 [simplification]
-    rule #lookup (  M:Map [ K1 <- _  ] , K2 )    => #lookup ( M         , K2 ) requires notBool ( K1 ==Int K2 ) [simplification]
-    rule #lookup ( (K1:Int |-> _) M:Map, K2:Int) => #lookup ( M         , K2 ) requires notBool ( K1 ==Int K2 ) [simplification]
+    // Symbolic lookup of map update
+    rule ( _:Map [ K1 <- V ] ):Map [ K2 ] => V            requires         K1 ==K K2 [simplification(45), preserves-definedness]
+    rule ( M:Map [ K1 <- _ ] ):Map [ K2 ] => M:Map [ K2 ] requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
+
+    // Symbolic membership of map update
+    rule K1 in_keys( _:Map [ K2 <- _ ] ) => true          requires         K1 ==K K2 [simplification(45), preserves-definedness]
+    rule K1 in_keys( M:Map [ K2 <- _ ] ) => K1 in_keys(M) requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
 
     rule M:Map [ I1:Int <- V1:Int ] [ I2:Int <- V2:Int ] ==K M:Map [ I2 <- V2 ] [ I1 <- V1 ] => true
       requires notBool ( I1 ==Int I2 )

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
@@ -117,29 +117,21 @@ module LEMMAS-WITHOUT-SLOT-UPDATES [symbolic]
     rule         keccak( _ ) <Int pow256 => true [simplification]
 
   // ########################
-  // Map and #lookup
+  // Map Reasoning
   // ########################
 
-    rule [lookup-lb]:                    0 <=Int #lookup( _:Map , _ ) => true [simplification, smt-lemma]
-    rule [lookup-up]: #lookup( _:Map , _ )  <Int pow256               => true [simplification, smt-lemma]
+    rule 0 <=Int #lookup( _M:Map , _ )             => true [simplification, smt-lemma]
+    rule         #lookup( _M:Map , _ ) <Int pow256 => true [simplification, smt-lemma]
 
-    // Symbolic lookup of map update
-    rule ( _:Map [ K1 <- V ] ):Map [ K2 ] => V            requires         K1 ==K K2 [simplification(45), preserves-definedness]
-    rule ( M:Map [ K1 <- _ ] ):Map [ K2 ] => M:Map [ K2 ] requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
-
-    // Symbolic membership of map concat
-    rule K1 in_keys( ( K2 |-> _ ) _:Map ) => true          requires         K1 ==K K2 [simplification(45), preserves-definedness]
-    rule K1 in_keys( ( K2 |-> _ ) M:Map ) => K1 in_keys(M) requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
-
-    // Symbolic membership of map update
-    rule K1 in_keys( _:Map [ K2 <- _ ] ) => true          requires         K1 ==K K2 [simplification(45), preserves-definedness]
-    rule K1 in_keys( M:Map [ K2 <- _ ] ) => K1 in_keys(M) requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
+    rule #lookup ( _M:Map [ K1 <- V1 ] , K2 )    => #lookup ( K1 |-> V1 , K1 ) requires K1 ==Int  K2 [simplification]
+    rule #lookup (  M:Map [ K1 <- _  ] , K2 )    => #lookup ( M         , K2 ) requires notBool ( K1 ==Int K2 ) [simplification]
+    rule #lookup ( (K1:Int |-> _) M:Map, K2:Int) => #lookup ( M         , K2 ) requires notBool ( K1 ==Int K2 ) [simplification]
 
     rule M:Map [ I1:Int <- V1:Int ] [ I2:Int <- V2:Int ] ==K M:Map [ I2 <- V2 ] [ I1 <- V1 ] => true
       requires notBool ( I1 ==Int I2 )
       [simplification]
 
- // Hardcoded #addrFromPrivateKey simplifications, see: https://github.com/runtimeverification/haskell-backend/issues/3573
+  // Hardcoded #addrFromPrivateKey simplifications, see: https://github.com/runtimeverification/haskell-backend/issues/3573
     rule #addrFromPrivateKey("0x0000000000000000000000000000000000000000000000000000000000000001") => 721457446580647751014191829380889690493307935711 [priority(40), concrete]
 
   // ########################

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
@@ -127,6 +127,10 @@ module LEMMAS-WITHOUT-SLOT-UPDATES [symbolic]
     rule ( _:Map [ K1 <- V ] ):Map [ K2 ] => V            requires         K1 ==K K2 [simplification(45), preserves-definedness]
     rule ( M:Map [ K1 <- _ ] ):Map [ K2 ] => M:Map [ K2 ] requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
 
+    // Symbolic membership of map concat
+    rule K1 in_keys( ( K2 -> _ ) _:Map ) => true          requires         K1 ==K K2 [simplification(45), preserves-definedness]
+    rule K1 in_keys( ( K2 -> _ ) M:Map ) => K1 in_keys(M) requires notBool K1 ==K K2 [simplification(45), preserves-definedness]
+
     // Symbolic membership of map update
     rule K1 in_keys( _:Map [ K2 <- _ ] ) => true          requires         K1 ==K K2 [simplification(45), preserves-definedness]
     rule K1 in_keys( M:Map [ K2 <- _ ] ) => K1 in_keys(M) requires notBool K1 ==K K2 [simplification(45), preserves-definedness]

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -9,7 +9,7 @@ module VERIFICATION-COMMON
   // Ecrecover
   // ########################
 
-    //Symbolic predicate representing whether output of #ecrec is empty. No implementation.
+    // Symbolic predicate representing whether output of #ecrec is empty. No implementation.
     syntax Bool ::= #ecrecEmpty( Bytes , Bytes , Bytes , Bytes ) [function, no-evaluators, smtlib(ecrecEmpty)]
  // ----------------------------------------------------------------------------------------------------------
     rule lengthBytes(#ecrec(HASH, SIGV, SIGR, SIGS)) => 32 requires notBool #ecrecEmpty(HASH, SIGV, SIGR, SIGS) [simplification]
@@ -18,11 +18,8 @@ module VERIFICATION-COMMON
     rule         #asWord(#ecrec(HASH, SIGV, SIGR, SIGS))             => 0    requires         #ecrecEmpty(HASH, SIGV, SIGR, SIGS) [simplification]
     rule 0  <Int #asWord(#ecrec(HASH, SIGV, SIGR, SIGS))             => true requires notBool #ecrecEmpty(HASH, SIGV, SIGR, SIGS) [simplification]
 
-    rule #Ceil( #ecrec(HASH, SIGV, SIGR, SIGS) ) => #Top
-     requires #ecrecEmpty(HASH, SIGV, SIGR, SIGS) [simplification]
-
-    rule #Ceil( #ecrec(HASH, SIGV, SIGR, SIGS) ) => #Top
-     requires notBool #ecrecEmpty(HASH, SIGV, SIGR, SIGS) [simplification]
+    rule #Ceil( #ecrec(HASH, SIGV, SIGR, SIGS) ) => #Top requires notBool #ecrecEmpty(HASH, SIGV, SIGR, SIGS) [simplification]
+    rule #Ceil( #ecrec(HASH, SIGV, SIGR, SIGS) ) => #Top requires         #ecrecEmpty(HASH, SIGV, SIGR, SIGS) [simplification]
 
 endmodule
 
@@ -141,6 +138,9 @@ module VERIFICATION-HASKELL [symbolic]
     rule BA1 +Bytes (BA2 +Bytes BA3) => (BA1 +Bytes BA2) +Bytes BA3 [concrete(BA1, BA2), simplification]
 
     rule maxUInt160 &Int Y => Y requires 0 <=Int Y andBool Y <=Int maxUInt160 [simplification]
+
+    rule lengthBytes ( #ecrec ( _ , _ , _ , _ ) ) <=Int     32 => true [simplification, smt-lemma]
+    rule     #asWord ( #ecrec ( _ , _ , _ , _ ) )  <Int pow160 => true [simplification, smt-lemma]
 
     rule ( lengthBytes(#ecrec( HASH, SIGV, SIGR, SIGS )) ==Int 0  ) =>           #ecrecEmpty ( HASH, SIGV, SIGR, SIGS )  [simplification]
     rule ( lengthBytes(#ecrec( HASH, SIGV, SIGR, SIGS )) ==Int 32 ) => notBool ( #ecrecEmpty ( HASH, SIGV, SIGR, SIGS )) [simplification]

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -34,12 +34,6 @@ module LEMMAS-SPEC
  // Arithmetic
  // ----------
 
-    claim <k> runLemma(#rangeUInt(256, #lookup(M, KX) -Int #lookup(M, KY))) => doneLemma(true) ... </k>
-      requires #rangeUInt(256, X) andBool X ==Int #lookup(M,  KX)
-       andBool #rangeUInt(256, Y) andBool Y ==Int #lookup(M,  KY)
-       andBool #rangeUInt(256, Z) andBool Z ==Int #lookup(M, _KZ)
-       andBool #rangeUInt(256, (X -Int Y) -Int Z)
-
     claim [address-reprojection]: <k> runLemma(((maxUInt160 &Int ((368263281805664599098893944405654396525700029268 |Int (notMaxUInt160 &Int X:Int)) modInt pow256)) modInt pow160))
                                    => doneLemma(368263281805664599098893944405654396525700029268) ... </k>
                                 requires #rangeUInt(256, X)

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -34,6 +34,12 @@ module LEMMAS-SPEC
  // Arithmetic
  // ----------
 
+    claim <k> runLemma(#rangeUInt(256, #lookup(M, KX) -Int #lookup(M, KY))) => doneLemma(true) ... </k>
+      requires #rangeUInt(256, X) andBool X ==Int #lookup(M,  KX)
+       andBool #rangeUInt(256, Y) andBool Y ==Int #lookup(M,  KY)
+       andBool #rangeUInt(256, Z) andBool Z ==Int #lookup(M, _KZ)
+       andBool #rangeUInt(256, (X -Int Y) -Int Z)
+
     claim [address-reprojection]: <k> runLemma(((maxUInt160 &Int ((368263281805664599098893944405654396525700029268 |Int (notMaxUInt160 &Int X:Int)) modInt pow256)) modInt pow160))
                                    => doneLemma(368263281805664599098893944405654396525700029268) ... </k>
                                 requires #rangeUInt(256, X)

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -811,8 +811,8 @@ module LEMMAS-SPEC
     claim [ecrec-range]: <k> runLemma  ( #rangeUInt ( 160 , #asWord ( #ecrec ( _ , _ , _ , _ ) ) ) )
                           => doneLemma ( true ) ... </k>
 
-    // claim [ecrec-mask]: <k> runLemma  ( #asWord ( #ecrec ( HASH , SIGV , SIGR , SIGS ) ) &Int maxUInt160 )
-    //                      => doneLemma ( #asWord ( #ecrec ( HASH , SIGV , SIGR , SIGS ) ) ) ... </k>
+    claim [ecrec-mask]: <k> runLemma  ( maxUInt160 &Int #asWord ( #ecrec ( HASH , SIGV , SIGR , SIGS ) ) )
+                         => doneLemma ( #asWord ( #ecrec ( HASH , SIGV , SIGR , SIGS ) ) ) ... </k>
 
  // Address computation
  // -------------------

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -176,13 +176,6 @@ module LEMMAS-SPEC
  // #lookup simplifications
  // -----------------------
 
-    claim <k> runLemma ( #lookupMemory(( KEY |-> 33) (_KEY' |-> 728) (_KEY'' |-> (pow256 +Int 5)) (_KEY''' |-> "hello"), KEY)    ) => doneLemma ( 33  ) ... </k>
-    claim <k> runLemma ( #lookupMemory((_KEY |-> 33) ( KEY' |-> 728) (_KEY'' |-> (pow256 +Int 5)) (_KEY''' |-> "hello"), KEY')   ) => doneLemma ( 216 ) ... </k>
-    claim <k> runLemma ( #lookupMemory((_KEY |-> 33) (_KEY' |-> 728) ( KEY'' |-> (pow256 +Int 5)) (_KEY''' |-> "hello"), KEY'')  ) => doneLemma ( 5   ) ... </k>
-    claim <k> runLemma ( #lookupMemory((_KEY |-> 33) (_KEY' |-> 728) (_KEY'' |-> (pow256 +Int 5)) ( KEY''' |-> "hello"), KEY''') ) => doneLemma ( 0   ) ... </k>
-    //TODO Haskell limitation? https://github.com/runtimeverification/haskell-backend/issues/1948
-    //claim <k> runLemma ( #lookupMemory((KEY |-> 33), KEY') ) => doneLemma ( 0 ) ... </k> requires notBool KEY' in_keys(KEY |-> 33)
-
     claim <k> runLemma ( #lookup(( KEY |-> 33) (_KEY' |-> 728) (_KEY'' |-> (pow256 +Int 5)) (_KEY''' |-> "hello"), KEY)    ) => doneLemma ( 33  ) ... </k>
     claim <k> runLemma ( #lookup((_KEY |-> 33) ( KEY' |-> 728) (_KEY'' |-> (pow256 +Int 5)) (_KEY''' |-> "hello"), KEY')   ) => doneLemma ( 728 ) ... </k>
     claim <k> runLemma ( #lookup((_KEY |-> 33) (_KEY' |-> 728) ( KEY'' |-> (pow256 +Int 5)) (_KEY''' |-> "hello"), KEY'')  ) => doneLemma ( 5   ) ... </k>

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -264,14 +264,12 @@ module LEMMAS-MCD [symbolic]
     rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
 
   // ########################
-   // Map
-   // ########################
+  // Map and #lookup
+  // ########################
 
     rule M:Bytes [ K <- V ]            [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]             requires K' <Int K                        [simplification]
     rule M [ K := BUF:Bytes ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K
                                                                                                orBool K +Int lengthBytes(BUF) <=Int K' [simplification]
-    rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
-
     rule M [ K := BUF:Bytes ] [ K' := BUF':Bytes ] => M [ K := (#range(BUF , 0 , K' -Int K )) ] [ K' := BUF' ]
        requires K <Int K'
         andBool K' <Int K +Int lengthBytes(BUF)
@@ -284,6 +282,11 @@ module LEMMAS-MCD [symbolic]
        requires K2 <=Int K1
         andBool K1 +Int lengthBytes(BUF11) <=Int K2 +Int lengthBytes(BUF2)
        [simplification]
+
+    rule 0 <=Int #lookup( _M:Map , _ )             => true [simplification, smt-lemma]
+    rule         #lookup( _M:Map , _ ) <Int pow256 => true [simplification, smt-lemma]
+
+    rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
 
   // ########################
   // Arithmetic

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -264,12 +264,14 @@ module LEMMAS-MCD [symbolic]
     rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
 
   // ########################
-  // Map and #lookup
-  // ########################
+   // Map
+   // ########################
 
     rule M:Bytes [ K <- V ]            [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]             requires K' <Int K                        [simplification]
     rule M [ K := BUF:Bytes ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K
                                                                                                orBool K +Int lengthBytes(BUF) <=Int K' [simplification]
+    rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
+
     rule M [ K := BUF:Bytes ] [ K' := BUF':Bytes ] => M [ K := (#range(BUF , 0 , K' -Int K )) ] [ K' := BUF' ]
        requires K <Int K'
         andBool K' <Int K +Int lengthBytes(BUF)
@@ -282,11 +284,6 @@ module LEMMAS-MCD [symbolic]
        requires K2 <=Int K1
         andBool K1 +Int lengthBytes(BUF11) <=Int K2 +Int lengthBytes(BUF2)
        [simplification]
-
-    rule 0 <=Int #lookup( _M:Map , _ )             => true [simplification, smt-lemma]
-    rule         #lookup( _M:Map , _ ) <Int pow256 => true [simplification, smt-lemma]
-
-    rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
 
   // ########################
   // Arithmetic


### PR DESCRIPTION
This PR removes several SMT lemmas from the main body of KEVM SMT lemmas and replaces them with appropriate simplifications.

The reason for the removal of the lemmas is that the functions in question:
- should never reach the SMT solver, in principle;
- overload Z3, making hard questions time out;
- are not required for either the test suite or engagement proofs to pass.