### PR TITLE
Update `copytree` function to support Python 3.12

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kdist/plugin.py
+++ b/kevm-pyk/src/kevm_pyk/kdist/plugin.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import shutil
 import sys
-from distutils.dir_util import copy_tree
 from typing import TYPE_CHECKING
 
 from pyk.kbuild.utils import k_version
@@ -52,7 +51,7 @@ class KEVMTarget(Target):
 
 class PluginTarget(Target):
     def build(self, output_dir: Path, deps: dict[str, Any], args: dict[str, Any], verbose: bool) -> None:
-        copy_tree(str(config.PLUGIN_DIR), '.')
+        shutil.copytree(str(config.PLUGIN_DIR), '.')
         run_process_2(['make', '-j8'])
         shutil.copy('./build/krypto/lib/krypto.a', str(output_dir))
 

--- a/kevm-pyk/src/kevm_pyk/kdist/plugin.py
+++ b/kevm-pyk/src/kevm_pyk/kdist/plugin.py
@@ -51,7 +51,7 @@ class KEVMTarget(Target):
 
 class PluginTarget(Target):
     def build(self, output_dir: Path, deps: dict[str, Any], args: dict[str, Any], verbose: bool) -> None:
-        shutil.copytree(str(config.PLUGIN_DIR), '.')
+        shutil.copytree(str(config.PLUGIN_DIR), '.', dirs_exist_ok=True)
         run_process_2(['make', '-j8'])
         shutil.copy('./build/krypto/lib/krypto.a', str(output_dir))
 

--- a/kevm-pyk/src/kevm_pyk/kdist/plugin.py
+++ b/kevm-pyk/src/kevm_pyk/kdist/plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
 import sys
 from typing import TYPE_CHECKING
 
@@ -52,6 +53,8 @@ class KEVMTarget(Target):
 class PluginTarget(Target):
     def build(self, output_dir: Path, deps: dict[str, Any], args: dict[str, Any], verbose: bool) -> None:
         shutil.copytree(str(config.PLUGIN_DIR), '.', dirs_exist_ok=True)
+        # Making the plugin directory readable and writable for nix
+        subprocess.run(['chmod', '-R', 'u+rw', '.'], check=True)
         run_process_2(['make', '-j8'])
         shutil.copy('./build/krypto/lib/krypto.a', str(output_dir))
 


### PR DESCRIPTION
The `distutils.dir_util` module we've been using to access `copy_tree` function is not available in Python 3.12, which is now [being using](https://github.com/runtimeverification/evm-semantics/actions/runs/12611910880/job/35148076043#step:4:7) in the Code Quality Checks CI stage:
```
src/kevm_pyk/kdist/plugin.py:5: error: Cannot find implementation or library stub for module named "distutils.dir_util"  [import-not-found]
src/kevm_pyk/kdist/plugin.py:5: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```

This PR imports this function from `shutil` instead, as discussed previously with @tothtamas28 and @Stevengre. It also makes the copied plugin folder and its files readable and writeable — otherwise, `nix build` complains about the missing permissions, because `shutil.copy*` functions handle permissions more conservatively than  `distutils.dir_util.copy_tree`.