### PR TITLE
Update loadTx rules in driver.md

### DIFF
--- a/kevm-pyk/src/kevm_pyk/gst_to_kore.py
+++ b/kevm-pyk/src/kevm_pyk/gst_to_kore.py
@@ -37,6 +37,7 @@ _GST_DISCARD_KEYS: Final = frozenset(
         'transactionSequence',
         'chainname',
         'lastblockhash',
+        'hasBigInt',
     ]
 )
 _GST_LOAD_KEYS: Final = frozenset(

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/driver.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/driver.md
@@ -83,9 +83,10 @@ To do so, we'll extend sort `JSON` with some EVM specific syntax, and provide a 
 
     syntax EthereumCommand ::= loadTx ( Account ) [symbol(loadTx)]
  // --------------------------------------------------------------
-    rule <k> loadTx(_) => #end EVMC_OUT_OF_GAS ... </k>
+    rule <k> loadTx(_) => startTx ... </k>
+         <statusCode> _ => EVMC_OUT_OF_GAS </statusCode>
+         <txPending> ListItem(TXID:Int) REST => REST </txPending>
          <schedule> SCHED </schedule>
-         <txPending> ListItem(TXID:Int) ... </txPending>
          <message>
            <msgID>      TXID     </msgID>
            <to>         .Account </to>

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/driver.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/driver.md
@@ -176,6 +176,10 @@ To do so, we'll extend sort `JSON` with some EVM specific syntax, and provide a 
          </account>
       requires notBool ACCTCODE ==K .Bytes
 
+    rule <k> loadTx(_) => startTx ... </k>
+         <statusCode> _ => EVMC_OUT_OF_GAS </statusCode>
+         <txPending> ListItem(_TXID:Int) REST => REST </txPending> [owise]
+
     syntax EthereumCommand ::= "#finishTx"
  // --------------------------------------
     rule <statusCode> _:ExceptionalStatusCode </statusCode> <k> #halt ~> #finishTx => #popCallStack ~> #popWorldState                   ... </k>

--- a/tests/failing.llvm
+++ b/tests/failing.llvm
@@ -132,8 +132,6 @@ BlockchainTests/GeneralStateTests/Pyspecs/constantinople/eip1014_create2/recreat
 BlockchainTests/GeneralStateTests/Pyspecs/frontier/opcodes/all_opcodes.json,src/GeneralStateTestsFiller/Pyspecs/frontier/opcodes/test_all_opcodes.py::test_all_opcodes[fork_Cancun-blockchain_test]
 BlockchainTests/GeneralStateTests/Pyspecs/frontier/opcodes/double_kill.json,*
 BlockchainTests/GeneralStateTests/Pyspecs/paris/security/tx_selfdestruct_balance_bug.json,*
-BlockchainTests/GeneralStateTests/Pyspecs/shanghai/eip3860_initcode/contract_creating_tx.json,src/GeneralStateTestsFiller/Pyspecs/shanghai/eip3860_initcode/test_initcode.py::test_contract_creating_tx[fork_Cancun-blockchain_test-over_limit_ones]
-BlockchainTests/GeneralStateTests/Pyspecs/shanghai/eip3860_initcode/contract_creating_tx.json,src/GeneralStateTestsFiller/Pyspecs/shanghai/eip3860_initcode/test_initcode.py::test_contract_creating_tx[fork_Cancun-blockchain_test-over_limit_zeros]
 BlockchainTests/GeneralStateTests/Pyspecs/shanghai/eip4895_withdrawals/balance_within_block.json,*
 BlockchainTests/GeneralStateTests/Pyspecs/shanghai/eip4895_withdrawals/large_amount.json,*
 BlockchainTests/GeneralStateTests/Pyspecs/shanghai/eip4895_withdrawals/many_withdrawals.json,*
@@ -145,7 +143,6 @@ BlockchainTests/GeneralStateTests/Pyspecs/shanghai/eip4895_withdrawals/use_value
 BlockchainTests/GeneralStateTests/Pyspecs/shanghai/eip4895_withdrawals/use_value_in_tx.json,*
 BlockchainTests/GeneralStateTests/Pyspecs/shanghai/eip4895_withdrawals/withdrawing_to_precompiles.json,*
 BlockchainTests/GeneralStateTests/Pyspecs/shanghai/eip4895_withdrawals/zero_amount.json,*
-BlockchainTests/GeneralStateTests/Shanghai/stEIP3860-limitmeterinitcode/creationTxInitCodeSizeLimit.json,creationTxInitCodeSizeLimit_d1g0v0_Cancun
 BlockchainTests/GeneralStateTests/stBadOpcode/opc49DiffPlaces.json,*
 BlockchainTests/GeneralStateTests/stBadOpcode/opc4ADiffPlaces.json,*
 BlockchainTests/GeneralStateTests/stBadOpcode/undefinedOpcodeFirstByte.json,*

--- a/tests/failing.llvm
+++ b/tests/failing.llvm
@@ -183,8 +183,4 @@ BlockchainTests/GeneralStateTests/stPreCompiledContracts/precompsEIP2929Cancun.j
 BlockchainTests/GeneralStateTests/stRevertTest/RevertInCreateInInit_Paris.json,*
 BlockchainTests/GeneralStateTests/stSpecialTest/failed_tx_xcf416c53_Paris.json,*
 BlockchainTests/GeneralStateTests/stSStoreTest/InitCollisionParis.json,*
-BlockchainTests/GeneralStateTests/stTransactionTest/NoSrcAccount1559.json,*
-BlockchainTests/GeneralStateTests/stTransactionTest/NoSrcAccountCreate1559.json,*
-BlockchainTests/GeneralStateTests/stTransactionTest/NoSrcAccountCreate.json,*
-BlockchainTests/GeneralStateTests/stTransactionTest/NoSrcAccount.json,*
 BlockchainTests/GeneralStateTests/stTransactionTest/ValueOverflowParis.json,*

--- a/tests/failing.llvm
+++ b/tests/failing.llvm
@@ -180,4 +180,3 @@ BlockchainTests/GeneralStateTests/stPreCompiledContracts/precompsEIP2929Cancun.j
 BlockchainTests/GeneralStateTests/stRevertTest/RevertInCreateInInit_Paris.json,*
 BlockchainTests/GeneralStateTests/stSpecialTest/failed_tx_xcf416c53_Paris.json,*
 BlockchainTests/GeneralStateTests/stSStoreTest/InitCollisionParis.json,*
-BlockchainTests/GeneralStateTests/stTransactionTest/ValueOverflowParis.json,*


### PR DESCRIPTION
1. For tests such as `NoSrcAccount1559.json,*`, where the sender of the transaction is not part of the account set provided, the execution would get stuck on `loadTx(ACCT)`. To address this I initially tried adding a rule such as
```k
    rule <k> loadTx(ACCTFROM:Int) => startTx ... </k>
         <statusCode> _ => EVMC_OUT_OF_GAS </statusCode>
         <txPending> ListItem(_TXID:Int) REST => REST </txPending>
         <accounts> ACCTS </accounts>
      requires notBool `AccountCellMap:in_keys`(<acctID> ACCTFROM </acctID>, ACCTS:AccountCellMap)
```
However, I was not able to run the test, having the interpreter crash with 
```bash
src/tests/integration/test_conformance.py:53: in _test
    res = interpret({test_name: test}, schedule, mode, chainid, usegas, check=False)
src/kevm_pyk/interpreter.py:24: in interpret
    kore = KoreParser(proc_res.stdout).pattern()
../../../../.cache/pypoetry/virtualenvs/kevm-pyk-jkAxdTav-py3.11/lib/python3.11/site-packages/pyk/kore/parser.py:202: in pattern
    name = self._match(TokenType.ID)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pyk.kore.parser.KoreParser object at 0x72589e645d90>
token_type = <TokenType.ID: 11>

    def _match(self, token_type: TokenType) -> str:
        if self._la.type != token_type:
>           raise ValueError(f'Expected {token_type.name}, found: {self._la.type.name}')
E           ValueError: Expected ID, found: EOF
```

So instead I ended up adding an `[owise]` rule.

2). Tests such as `test_contract_creating_tx[fork_Cancun-blockchain_test-over_limit_ones]` were failing for Cancun because of the BeaconRoots contract storage check. The storage of this account is modified at the start of a block with the timestamp value.  Because the transactions in the test are invalid ( and so are the blocks) the storage of the BeaconRoots contract is expected to be empty at the end of the tests. I updated the rule to skip the transaction instead of starting it.