### PR TITLE
Add rule names in `schedule.md`

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -198,7 +198,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 
     rule [GselfdestructnewaccountTangerine]:   Gselfdestructnewaccount << TANGERINE_WHISTLE >> => true
     rule [GstaticcalldepthTangerine]:          Gstaticcalldepth        << TANGERINE_WHISTLE >> => false
-    rule [SCHEDFLAGTangerine]:                SCHEDCONST              << TANGERINE_WHISTLE >> => SCHEDCONST << HOMESTEAD >>
+    rule [SCHEDFLAGTangerine]:                 SCHEDFLAG               << TANGERINE_WHISTLE >> => SCHEDFLAG << HOMESTEAD >>
       requires notBool ( SCHEDCONST ==K Gselfdestructnewaccount orBool SCHEDCONST ==K Gstaticcalldepth )
 ```
 
@@ -215,7 +215,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 
     rule [GemptyisnonexistentDragon]:     Gemptyisnonexistent     << SPURIOUS_DRAGON >> => true
     rule [GzerovaluenewaccountgasDragon]: Gzerovaluenewaccountgas << SPURIOUS_DRAGON >> => false
-    rule [SCHEDFLAGDragon]:              SCHEDCONST              << SPURIOUS_DRAGON >> => SCHEDCONST << TANGERINE_WHISTLE >>
+    rule [SCHEDFLAGDragon]:               SCHEDFLAG               << SPURIOUS_DRAGON >> => SCHEDFLAG << TANGERINE_WHISTLE >>
       requires notBool ( SCHEDCONST ==K Gemptyisnonexistent orBool SCHEDCONST ==K Gzerovaluenewaccountgas )
 ```
 
@@ -224,7 +224,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "BYZANTIUM" [symbol(BYZANTIUM_EVM), smtlib(schedule_BYZANTIUM)]
  // -----------------------------------------------------------------------------------
-    rule [RbByzantium]:      Rb         < BYZANTIUM > => 3 *Int eth
+    rule [RbByzantium]:         Rb         < BYZANTIUM > => 3 *Int eth
     rule [SCHEDCONSTByzantium]: SCHEDCONST < BYZANTIUM > => SCHEDCONST < SPURIOUS_DRAGON >
       requires notBool ( SCHEDCONST ==K Rb )
 
@@ -406,7 +406,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule [Ghaseip6780Cancun]:     Ghaseip6780     << CANCUN >> => true
     rule [GhasblobbasefeeCancun]: Ghasblobbasefee << CANCUN >> => true
     rule [GhasblobhashCancun]:    Ghasblobhash    << CANCUN >> => true
-    rule [SCHEDFLAGCancun]:       SCHEDFLAG      << CANCUN >> => SCHEDFLAG << SHANGHAI >>
+    rule [SCHEDFLAGCancun]:       SCHEDFLAG       << CANCUN >> => SCHEDFLAG << SHANGHAI >>
       requires notBool ( SCHEDFLAG ==K Ghastransient
                   orBool SCHEDFLAG ==K Ghasmcopy
                   orBool SCHEDFLAG ==K Ghasbeaconroot

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -57,105 +57,105 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "DEFAULT" [symbol(DEFAULT_EVM), smtlib(schedule_DEFAULT)]
  // -----------------------------------------------------------------------------
-    rule Gzero    < DEFAULT > => 0
-    rule Gbase    < DEFAULT > => 2
-    rule Gverylow < DEFAULT > => 3
-    rule Glow     < DEFAULT > => 5
-    rule Gmid     < DEFAULT > => 8
-    rule Ghigh    < DEFAULT > => 10
+    rule [GzeroDefault]    Gzero    < DEFAULT > => 0
+    rule [GbaseDefault]    Gbase    < DEFAULT > => 2
+    rule [GverylowDefault] Gverylow < DEFAULT > => 3
+    rule [GlowDefault]     Glow     < DEFAULT > => 5
+    rule [GmidDefault]     Gmid     < DEFAULT > => 8
+    rule [GhighDefault]    Ghigh    < DEFAULT > => 10
 
-    rule Gexp      < DEFAULT > => 10
-    rule Gexpbyte  < DEFAULT > => 10
-    rule Gsha3     < DEFAULT > => 30
-    rule Gsha3word < DEFAULT > => 6
+    rule [GexpDefault]      Gexp      < DEFAULT > => 10
+    rule [GexpbyteDefault]  Gexpbyte  < DEFAULT > => 10
+    rule [Gsha3Default]     Gsha3     < DEFAULT > => 30
+    rule [Gsha3wordDefault] Gsha3word < DEFAULT > => 6
 
-    rule Gsload       < DEFAULT > => 50
-    rule Gsstoreset   < DEFAULT > => 20000
-    rule Gsstorereset < DEFAULT > => 5000
-    rule Rsstoreclear < DEFAULT > => 15000
+    rule [GsloadDefault]       Gsload       < DEFAULT > => 50
+    rule [GsstoresetDefault]   Gsstoreset   < DEFAULT > => 20000
+    rule [GsstoreresetDefault] Gsstorereset < DEFAULT > => 5000
+    rule [RsstoreclearDefault] Rsstoreclear < DEFAULT > => 15000
 
-    rule Glog      < DEFAULT > => 375
-    rule Glogdata  < DEFAULT > => 8
-    rule Glogtopic < DEFAULT > => 375
+    rule [GlogDefault]      Glog      < DEFAULT > => 375
+    rule [GlogdataDefault]  Glogdata  < DEFAULT > => 8
+    rule [GlogtopicDefault] Glogtopic < DEFAULT > => 375
 
-    rule Gcall        < DEFAULT > => 40
-    rule Gcallstipend < DEFAULT > => 2300
-    rule Gcallvalue   < DEFAULT > => 9000
-    rule Gnewaccount  < DEFAULT > => 25000
+    rule [GcallDefault]        Gcall        < DEFAULT > => 40
+    rule [GcallstipendDefault] Gcallstipend < DEFAULT > => 2300
+    rule [GcallvalueDefault]   Gcallvalue   < DEFAULT > => 9000
+    rule [GnewaccountDefault]  Gnewaccount  < DEFAULT > => 25000
 
-    rule Gcreate       < DEFAULT > => 32000
-    rule Gcodedeposit  < DEFAULT > => 200
-    rule Gselfdestruct < DEFAULT > => 0
-    rule Rselfdestruct < DEFAULT > => 24000
+    rule [GcreateDefault]       Gcreate       < DEFAULT > => 32000
+    rule [GcodedepositDefault]  Gcodedeposit  < DEFAULT > => 200
+    rule [GselfdestructDefault] Gselfdestruct < DEFAULT > => 0
+    rule [RselfdestructDefault] Rselfdestruct < DEFAULT > => 24000
 
-    rule Gmemory      < DEFAULT > => 3
-    rule Gquadcoeff   < DEFAULT > => 512
-    rule Gcopy        < DEFAULT > => 3
-    rule Gquaddivisor < DEFAULT > => 20
+    rule [GmemoryDefault]      Gmemory      < DEFAULT > => 3
+    rule [GquadcoeffDefault]   Gquadcoeff   < DEFAULT > => 512
+    rule [GcopyDefault]        Gcopy        < DEFAULT > => 3
+    rule [GquaddivisorDefault] Gquaddivisor < DEFAULT > => 20
 
-    rule Gtransaction   < DEFAULT > => 21000
-    rule Gtxcreate      < DEFAULT > => 53000
-    rule Gtxdatazero    < DEFAULT > => 4
-    rule Gtxdatanonzero < DEFAULT > => 68
+    rule [GtransactionDefault]   Gtransaction   < DEFAULT > => 21000
+    rule [GtxcreateDefault]      Gtxcreate      < DEFAULT > => 53000
+    rule [GtxdatazeroDefault]    Gtxdatazero    < DEFAULT > => 4
+    rule [GtxdatanonzeroDefault] Gtxdatanonzero < DEFAULT > => 68
 
-    rule Gjumpdest    < DEFAULT > => 1
-    rule Gbalance     < DEFAULT > => 20
-    rule Gblockhash   < DEFAULT > => 20
-    rule Gextcodesize < DEFAULT > => 20
-    rule Gextcodecopy < DEFAULT > => 20
+    rule [GjumpdestDefault]    Gjumpdest    < DEFAULT > => 1
+    rule [GbalanceDefault]     Gbalance     < DEFAULT > => 20
+    rule [GblockhashDefault]   Gblockhash   < DEFAULT > => 20
+    rule [GextcodesizeDefault] Gextcodesize < DEFAULT > => 20
+    rule [GextcodecopyDefault] Gextcodecopy < DEFAULT > => 20
 
-    rule Gecadd       < DEFAULT > => 500
-    rule Gecmul       < DEFAULT > => 40000
-    rule Gecpairconst < DEFAULT > => 100000
-    rule Gecpaircoeff < DEFAULT > => 80000
-    rule Gfround      < DEFAULT > => 1
+    rule [GecaddDefault]       Gecadd       < DEFAULT > => 500
+    rule [GecmulDefault]       Gecmul       < DEFAULT > => 40000
+    rule [GecpairconstDefault] Gecpairconst < DEFAULT > => 100000
+    rule [GecpaircoeffDefault] Gecpaircoeff < DEFAULT > => 80000
+    rule [GfroundDefault]      Gfround      < DEFAULT > => 1
 
-    rule maxCodeSize < DEFAULT > => 2 ^Int 32 -Int 1
-    rule Rb          < DEFAULT > => 5 *Int (10 ^Int 18)
+    rule [maxCodeSizeDefault] maxCodeSize < DEFAULT > => 2 ^Int 32 -Int 1
+    rule [RbDefault]          Rb          < DEFAULT > => 5 *Int (10 ^Int 18)
 
-    rule Gcoldsload             < DEFAULT > => 0
-    rule Gcoldaccountaccess     < DEFAULT > => 0
-    rule Gwarmstorageread       < DEFAULT > => 0
-    rule Gwarmstoragedirtystore < DEFAULT > => 0
+    rule [GcoldsloadDefault]             Gcoldsload             < DEFAULT > => 0
+    rule [GcoldaccountaccessDefault]     Gcoldaccountaccess     < DEFAULT > => 0
+    rule [GwarmstoragereadDefault]       Gwarmstorageread       < DEFAULT > => 0
+    rule [GwarmstoragedirtystoreDefault] Gwarmstoragedirtystore < DEFAULT > => 0
 
-    rule Gpointeval < DEFAULT > => 0
+    rule [GpointevalDefault] Gpointeval < DEFAULT > => 0
 
-    rule Gaccessliststoragekey < DEFAULT > => 0
-    rule Gaccesslistaddress    < DEFAULT > => 0
+    rule [GaccessliststoragekeyDefault] Gaccessliststoragekey < DEFAULT > => 0
+    rule [GaccesslistaddressDefault]    Gaccesslistaddress    < DEFAULT > => 0
 
-    rule maxInitCodeSize   < DEFAULT > => 0
-    rule Ginitcodewordcost < DEFAULT > => 0
+    rule [maxInitCodeSizeDefault]   maxInitCodeSize   < DEFAULT > => 0
+    rule [GinitcodewordcostDefault] Ginitcodewordcost < DEFAULT > => 0
 
-    rule Rmaxquotient < DEFAULT > => 2
+    rule [RmaxquotientDefault] Rmaxquotient < DEFAULT > => 2
 
-    rule Gselfdestructnewaccount << DEFAULT >> => false
-    rule Gstaticcalldepth        << DEFAULT >> => true
-    rule Gemptyisnonexistent     << DEFAULT >> => false
-    rule Gzerovaluenewaccountgas << DEFAULT >> => true
-    rule Ghasrevert              << DEFAULT >> => false
-    rule Ghasreturndata          << DEFAULT >> => false
-    rule Ghasstaticcall          << DEFAULT >> => false
-    rule Ghasshift               << DEFAULT >> => false
-    rule Ghasdirtysstore         << DEFAULT >> => false
-    rule Ghassstorestipend       << DEFAULT >> => false
-    rule Ghascreate2             << DEFAULT >> => false
-    rule Ghasextcodehash         << DEFAULT >> => false
-    rule Ghasselfbalance         << DEFAULT >> => false
-    rule Ghaschainid             << DEFAULT >> => false
-    rule Ghasaccesslist          << DEFAULT >> => false
-    rule Ghasbasefee             << DEFAULT >> => false
-    rule Ghasblobbasefee         << DEFAULT >> => false
-    rule Ghasrejectedfirstbyte   << DEFAULT >> => false
-    rule Ghasprevrandao          << DEFAULT >> => false
-    rule Ghasmaxinitcodesize     << DEFAULT >> => false
-    rule Ghaspushzero            << DEFAULT >> => false
-    rule Ghaswarmcoinbase        << DEFAULT >> => false
-    rule Ghaswithdrawals         << DEFAULT >> => false
-    rule Ghastransient           << DEFAULT >> => false
-    rule Ghasmcopy               << DEFAULT >> => false
-    rule Ghasbeaconroot          << DEFAULT >> => false
-    rule Ghaseip6780             << DEFAULT >> => false
-    rule Ghasblobhash            << DEFAULT >> => false
+    rule [GselfdestructnewaccountDefault] Gselfdestructnewaccount << DEFAULT >> => false
+    rule [GstaticcalldepthDefault]        Gstaticcalldepth        << DEFAULT >> => true
+    rule [GemptyisnonexistentDefault]     Gemptyisnonexistent     << DEFAULT >> => false
+    rule [GzerovaluenewaccountgasDefault] Gzerovaluenewaccountgas << DEFAULT >> => true
+    rule [GhasrevertDefault]              Ghasrevert              << DEFAULT >> => false
+    rule [GhasreturndataDefault]          Ghasreturndata          << DEFAULT >> => false
+    rule [GhasstaticcallDefault]          Ghasstaticcall          << DEFAULT >> => false
+    rule [GhasshiftDefault]               Ghasshift               << DEFAULT >> => false
+    rule [GhasdirtysstoreDefault]         Ghasdirtysstore         << DEFAULT >> => false
+    rule [GhassstorestipendDefault]       Ghassstorestipend       << DEFAULT >> => false
+    rule [Ghascreate2Default]             Ghascreate2             << DEFAULT >> => false
+    rule [GhasextcodehashDefault]         Ghasextcodehash         << DEFAULT >> => false
+    rule [GhasselfbalanceDefault]         Ghasselfbalance         << DEFAULT >> => false
+    rule [GhaschainidDefault]             Ghaschainid             << DEFAULT >> => false
+    rule [GhasaccesslistDefault]          Ghasaccesslist          << DEFAULT >> => false
+    rule [GhasbasefeeDefault]             Ghasbasefee             << DEFAULT >> => false
+    rule [GhasblobbasefeeDefault]         Ghasblobbasefee         << DEFAULT >> => false
+    rule [GhasrejectedfirstbyteDefault]   Ghasrejectedfirstbyte   << DEFAULT >> => false
+    rule [GhasprevrandaoDefault]          Ghasprevrandao          << DEFAULT >> => false
+    rule [GhasmaxinitcodesizeDefault]     Ghasmaxinitcodesize     << DEFAULT >> => false
+    rule [GhaspushzeroDefault]            Ghaspushzero            << DEFAULT >> => false
+    rule [GhaswarmcoinbaseDefault]        Ghaswarmcoinbase        << DEFAULT >> => false
+    rule [GhaswithdrawalsDefault]         Ghaswithdrawals         << DEFAULT >> => false
+    rule [GhastransientDefault]           Ghastransient           << DEFAULT >> => false
+    rule [GhasmcopyDefault]               Ghasmcopy               << DEFAULT >> => false
+    rule [GhasbeaconrootDefault]          Ghasbeaconroot          << DEFAULT >> => false
+    rule [Ghaseip6780Default]             Ghaseip6780             << DEFAULT >> => false
+    rule [GhasblobhashDefault]            Ghasblobhash            << DEFAULT >> => false
 ```
 
 ### Frontier Schedule
@@ -163,10 +163,10 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "FRONTIER" [symbol(FRONTIER_EVM), smtlib(schedule_FRONTIER)]
  // --------------------------------------------------------------------------------
-    rule Gtxcreate  < FRONTIER > => 21000
-    rule SCHEDCONST < FRONTIER > => SCHEDCONST < DEFAULT > requires SCHEDCONST =/=K Gtxcreate
+    rule [GtxcreateFrontier]  Gtxcreate  < FRONTIER > => 21000
+    rule [SCHEDCONSTFrontier] SCHEDCONST < FRONTIER > => SCHEDCONST < DEFAULT > requires SCHEDCONST =/=K  Gtxcreate
 
-    rule SCHEDFLAG << FRONTIER >> => SCHEDFLAG << DEFAULT >>
+    rule [SCHEDFLAGFrontier] SCHEDFLAG << FRONTIER >> => SCHEDFLAG << DEFAULT >>
 ```
 
 ### Homestead Schedule
@@ -174,9 +174,9 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "HOMESTEAD" [symbol(HOMESTEAD_EVM), smtlib(schedule_HOMESTEAD)]
  // -----------------------------------------------------------------------------------
-    rule SCHEDCONST < HOMESTEAD > => SCHEDCONST < DEFAULT >
+    rule [SCHEDCONSTHomestead] SCHEDCONST < HOMESTEAD > => SCHEDCONST < DEFAULT >
 
-    rule SCHEDFLAG << HOMESTEAD >> => SCHEDFLAG << DEFAULT >>
+    rule [SCHEDFLAGHomestead] SCHEDFLAG << HOMESTEAD >> => SCHEDFLAG << DEFAULT >>
 ```
 
 ### Tangerine Whistle Schedule
@@ -184,22 +184,22 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "TANGERINE_WHISTLE" [symbol(TANGERINE_WHISTLE_EVM), smtlib(schedule_TANGERINE_WHISTLE)]
  // -----------------------------------------------------------------------------------------------------------
-    rule Gbalance      < TANGERINE_WHISTLE > => 400
-    rule Gsload        < TANGERINE_WHISTLE > => 200
-    rule Gcall         < TANGERINE_WHISTLE > => 700
-    rule Gselfdestruct < TANGERINE_WHISTLE > => 5000
-    rule Gextcodesize  < TANGERINE_WHISTLE > => 700
-    rule Gextcodecopy  < TANGERINE_WHISTLE > => 700
+    rule [GbalanceTangerine]      Gbalance      < TANGERINE_WHISTLE > => 400
+    rule [GsloadTangerine]        Gsload        < TANGERINE_WHISTLE > => 200
+    rule [GcallTangerine]         Gcall         < TANGERINE_WHISTLE > => 700
+    rule [GselfdestructTangerine] Gselfdestruct < TANGERINE_WHISTLE > => 5000
+    rule [GextcodesizeTangerine]  Gextcodesize  < TANGERINE_WHISTLE > => 700
+    rule [GextcodecopyTangerine]  Gextcodecopy  < TANGERINE_WHISTLE > => 700
 
-    rule SCHEDCONST    < TANGERINE_WHISTLE > => SCHEDCONST < HOMESTEAD >
-      requires notBool      ( SCHEDCONST ==K Gbalance      orBool SCHEDCONST ==K Gsload       orBool SCHEDCONST ==K Gcall
-                       orBool SCHEDCONST ==K Gselfdestruct orBool SCHEDCONST ==K Gextcodesize orBool SCHEDCONST ==K Gextcodecopy
-                            )
+    rule [SCHEDCONSTTangerine] SCHEDCONST    < TANGERINE_WHISTLE > => SCHEDCONST < HOMESTEAD >
+      requires notBool ( SCHEDCONST ==K Gbalance      orBool SCHEDCONST ==K Gsload       orBool SCHEDCONST ==K Gcall
+                  orBool SCHEDCONST ==K Gselfdestruct orBool SCHEDCONST ==K Gextcodesize orBool SCHEDCONST ==K Gextcodecopy
+                       )
 
-    rule Gselfdestructnewaccount << TANGERINE_WHISTLE >> => true
-    rule Gstaticcalldepth        << TANGERINE_WHISTLE >> => false
-    rule SCHEDCONST              << TANGERINE_WHISTLE >> => SCHEDCONST << HOMESTEAD >>
-      requires notBool      ( SCHEDCONST ==K Gselfdestructnewaccount orBool SCHEDCONST ==K Gstaticcalldepth )
+    rule [GselfdestructnewaccountTangerine]   Gselfdestructnewaccount << TANGERINE_WHISTLE >> => true
+    rule [GstaticcalldepthTangerine]          Gstaticcalldepth        << TANGERINE_WHISTLE >> => false
+    rule [SCHEDCONSTTangerine]                SCHEDCONST              << TANGERINE_WHISTLE >> => SCHEDCONST << HOMESTEAD >>
+      requires notBool ( SCHEDCONST ==K  Gselfdestructnewaccount orBool SCHEDCONST ==K Gstaticcalldepth )
 ```
 
 ### Spurious Dragon Schedule
@@ -207,15 +207,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "SPURIOUS_DRAGON" [symbol(SPURIOUS_DRAGON_EVM), smtlib(schedule_SPURIOUS_DRAGON)]
  // -----------------------------------------------------------------------------------------------------
-    rule Gexpbyte    < SPURIOUS_DRAGON > => 50
-    rule maxCodeSize < SPURIOUS_DRAGON > => 24576
+    rule [GexpbyteDragon]    Gexpbyte    < SPURIOUS_DRAGON > => 50
+    rule [maxCodeSizeDragon] maxCodeSize < SPURIOUS_DRAGON > => 24576
 
-    rule SCHEDCONST  < SPURIOUS_DRAGON > => SCHEDCONST < TANGERINE_WHISTLE > requires SCHEDCONST =/=K Gexpbyte andBool SCHEDCONST =/=K maxCodeSize
+    rule [SCHEDCONSTDragon] SCHEDCONST  < SPURIOUS_DRAGON > => SCHEDCONST < TANGERINE_WHISTLE >
+      requires SCHEDCONST =/=K  Gexpbyte andBool SCHEDCONST =/=K maxCodeSize
 
-    rule Gemptyisnonexistent     << SPURIOUS_DRAGON >> => true
-    rule Gzerovaluenewaccountgas << SPURIOUS_DRAGON >> => false
-    rule SCHEDCONST              << SPURIOUS_DRAGON >> => SCHEDCONST << TANGERINE_WHISTLE >>
-      requires notBool      ( SCHEDCONST ==K Gemptyisnonexistent orBool SCHEDCONST ==K Gzerovaluenewaccountgas )
+    rule [GemptyisnonexistentDragon]     Gemptyisnonexistent     << SPURIOUS_DRAGON >> => true
+    rule [GzerovaluenewaccountgasDragon] Gzerovaluenewaccountgas << SPURIOUS_DRAGON >> => false
+    rule [SCHEDCONSTDragon]              SCHEDCONST              << SPURIOUS_DRAGON >> => SCHEDCONST << TANGERINE_WHISTLE >>
+      requires notBool ( SCHEDCONST ==K  Gemptyisnonexistent orBool SCHEDCONST ==K Gzerovaluenewaccountgas )
 ```
 
 ### Byzantium Schedule
@@ -223,15 +224,15 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "BYZANTIUM" [symbol(BYZANTIUM_EVM), smtlib(schedule_BYZANTIUM)]
  // -----------------------------------------------------------------------------------
-    rule Rb         < BYZANTIUM > => 3 *Int eth
-    rule SCHEDCONST < BYZANTIUM > => SCHEDCONST < SPURIOUS_DRAGON >
+    rule [RbByzantium]      Rb         < BYZANTIUM > => 3 *Int eth
+    rule [SCHEDCONSTDragon] SCHEDCONST < BYZANTIUM > => SCHEDCONST < SPURIOUS_DRAGON >
       requires notBool ( SCHEDCONST ==K Rb )
 
-    rule Ghasrevert     << BYZANTIUM >> => true
-    rule Ghasreturndata << BYZANTIUM >> => true
-    rule Ghasstaticcall << BYZANTIUM >> => true
-    rule SCHEDFLAG      << BYZANTIUM >> => SCHEDFLAG << SPURIOUS_DRAGON >>
-      requires notBool ( SCHEDFLAG ==K Ghasrevert orBool SCHEDFLAG ==K Ghasreturndata orBool SCHEDFLAG ==K Ghasstaticcall )
+    rule [GhasrevertDragon]     Ghasrevert     << BYZANTIUM >> => true
+    rule [GhasreturndataDragon] Ghasreturndata << BYZANTIUM >> => true
+    rule [GhasstaticcallDragon] Ghasstaticcall << BYZANTIUM >> => true
+    rule [SCHEDFLAGDragon]      SCHEDFLAG      << BYZANTIUM >> => SCHEDFLAG << SPURIOUS_DRAGON >>
+      requires notBool ( SCHEDFLAG ==K  Ghasrevert orBool SCHEDFLAG ==K Ghasreturndata orBool SCHEDFLAG ==K Ghasstaticcall )
 ```
 
 ### Constantinople Schedule
@@ -239,16 +240,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "CONSTANTINOPLE" [symbol(CONSTANTINOPLE_EVM), smtlib(schedule_CONSTANTINOPLE)]
  // --------------------------------------------------------------------------------------------------
-    rule Rb         < CONSTANTINOPLE > => 2 *Int eth
-    rule SCHEDCONST < CONSTANTINOPLE > => SCHEDCONST < BYZANTIUM >
+    rule [RbConstantinople]         Rb         < CONSTANTINOPLE > => 2 *Int eth
+    rule [SCHEDCONSTConstantinople] SCHEDCONST < CONSTANTINOPLE > => SCHEDCONST < BYZANTIUM >
       requires notBool ( SCHEDCONST ==K Rb )
 
-    rule Ghasshift       << CONSTANTINOPLE >> => true
-    rule Ghasdirtysstore << CONSTANTINOPLE >> => true
-    rule Ghascreate2     << CONSTANTINOPLE >> => true
-    rule Ghasextcodehash << CONSTANTINOPLE >> => true
-    rule SCHEDFLAG       << CONSTANTINOPLE >> => SCHEDFLAG << BYZANTIUM >>
-      requires notBool ( SCHEDFLAG ==K Ghasshift orBool SCHEDFLAG ==K Ghasdirtysstore orBool SCHEDFLAG ==K Ghascreate2 orBool SCHEDFLAG ==K Ghasextcodehash )
+    rule [GhasshiftConstantinople]       Ghasshift       << CONSTANTINOPLE >> => true
+    rule [GhasdirtysstoreConstantinople] Ghasdirtysstore << CONSTANTINOPLE >> => true
+    rule [Ghascreate2Constantinople]     Ghascreate2     << CONSTANTINOPLE >> => true
+    rule [GhasextcodehashConstantinople] Ghasextcodehash << CONSTANTINOPLE >> => true
+    rule [SCHEDFLAGConstantinople]       SCHEDFLAG       << CONSTANTINOPLE >> => SCHEDFLAG << BYZANTIUM >>
+      requires notBool ( SCHEDFLAG ==K   Ghasshift orBool SCHEDFLAG ==K Ghasdirtysstore orBool SCHEDFLAG ==K Ghascreate2 orBool SCHEDFLAG ==K Ghasextcodehash )
 ```
 
 ### Petersburg Schedule
@@ -256,10 +257,10 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "PETERSBURG" [symbol(PETERSBURG_EVM), smtlib(schedule_PETERSBURG)]
  // --------------------------------------------------------------------------------------
-    rule SCHEDCONST < PETERSBURG > => SCHEDCONST < CONSTANTINOPLE >
+    rule [SCHEDCONSTPetersburg] SCHEDCONST < PETERSBURG > => SCHEDCONST < CONSTANTINOPLE >
 
-    rule Ghasdirtysstore << PETERSBURG >> => false
-    rule SCHEDFLAG       << PETERSBURG >> => SCHEDFLAG << CONSTANTINOPLE >>
+    rule [GhasdirtysstorePetersburg] Ghasdirtysstore << PETERSBURG >> => false
+    rule [SCHEDFLAGPetersburg]       SCHEDFLAG       << PETERSBURG >> => SCHEDFLAG << CONSTANTINOPLE >>
       requires notBool ( SCHEDFLAG ==K Ghasdirtysstore )
 ```
 
@@ -268,14 +269,14 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "ISTANBUL" [symbol(ISTANBUL_EVM), smtlib(schedule_ISTANBUL)]
  // --------------------------------------------------------------------------------
-    rule Gecadd         < ISTANBUL > => 150
-    rule Gecmul         < ISTANBUL > => 6000
-    rule Gecpairconst   < ISTANBUL > => 45000
-    rule Gecpaircoeff   < ISTANBUL > => 34000
-    rule Gtxdatanonzero < ISTANBUL > => 16
-    rule Gsload         < ISTANBUL > => 800
-    rule Gbalance       < ISTANBUL > => 700
-    rule SCHEDCONST     < ISTANBUL > => SCHEDCONST < PETERSBURG >
+    rule [GecaddIstanbul]         Gecadd         < ISTANBUL > => 150
+    rule [GecmulIstanbul]         Gecmul         < ISTANBUL > => 6000
+    rule [GecpairconstIstanbul]   Gecpairconst   < ISTANBUL > => 45000
+    rule [GecpaircoeffIstanbul]   Gecpaircoeff   < ISTANBUL > => 34000
+    rule [GtxdatanonzeroIstanbul] Gtxdatanonzero < ISTANBUL > => 16
+    rule [GsloadIstanbul]         Gsload         < ISTANBUL > => 800
+    rule [GbalanceIstanbul]       Gbalance       < ISTANBUL > => 700
+    rule [SCHEDCONSTIstanbul]     SCHEDCONST     < ISTANBUL > => SCHEDCONST < PETERSBURG >
       requires notBool ( SCHEDCONST ==K Gecadd
                   orBool SCHEDCONST ==K Gecmul
                   orBool SCHEDCONST ==K Gecpairconst
@@ -285,11 +286,11 @@ A `ScheduleConst` is a constant determined by the fee schedule.
                   orBool SCHEDCONST ==K Gbalance
                        )
 
-    rule Ghasselfbalance   << ISTANBUL >> => true
-    rule Ghasdirtysstore   << ISTANBUL >> => true
-    rule Ghassstorestipend << ISTANBUL >> => true
-    rule Ghaschainid       << ISTANBUL >> => true
-    rule SCHEDFLAG         << ISTANBUL >> => SCHEDFLAG << PETERSBURG >>
+    rule [GhasselfbalanceIstanbul]   Ghasselfbalance   << ISTANBUL >> => true
+    rule [GhasdirtysstoreIstanbul]   Ghasdirtysstore   << ISTANBUL >> => true
+    rule [GhassstorestipendIstanbul] Ghassstorestipend << ISTANBUL >> => true
+    rule [GhaschainidIstanbul]       Ghaschainid       << ISTANBUL >> => true
+    rule [SCHEDFLAGIstanbul]         SCHEDFLAG         << ISTANBUL >> => SCHEDFLAG << PETERSBURG >>
       requires notBool ( SCHEDFLAG ==K Ghasselfbalance
                   orBool SCHEDFLAG ==K Ghasdirtysstore
                   orBool SCHEDFLAG ==K Ghassstorestipend
@@ -302,16 +303,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "BERLIN" [symbol(BERLIN_EVM), smtlib(schedule_BERLIN)]
  // --------------------------------------------------------------------------
-    rule Gcoldsload            < BERLIN > => 2100
-    rule Gcoldaccountaccess    < BERLIN > => 2600
-    rule Gwarmstorageread      < BERLIN > => 100
-    rule Gsload                < BERLIN > => Gwarmstorageread < BERLIN >
-    rule Gsstorereset          < BERLIN > => 5000 -Int Gcoldsload < BERLIN >
-    rule Gquaddivisor          < BERLIN > => 3
-    rule Gaccessliststoragekey < BERLIN > => 1900
-    rule Gaccesslistaddress    < BERLIN > => 2400
+    rule [GcoldsloadBerlin]            Gcoldsload            < BERLIN > => 2100
+    rule [GcoldaccountaccessBerlin]    Gcoldaccountaccess    < BERLIN > => 2600
+    rule [GwarmstoragereadBerlin]      Gwarmstorageread      < BERLIN > => 100
+    rule [GsloadBerlin]                Gsload                < BERLIN > => Gwarmstorageread < BERLIN >
+    rule [GsstoreresetBerlin]          Gsstorereset          < BERLIN > => 5000 -Int Gcoldsload < BERLIN >
+    rule [GquaddivisorBerlin]          Gquaddivisor          < BERLIN > => 3
+    rule [GaccessliststoragekeyBerlin] Gaccessliststoragekey < BERLIN > => 1900
+    rule [GaccesslistaddressBerlin]    Gaccesslistaddress    < BERLIN > => 2400
 
-    rule SCHEDCONST            < BERLIN > => SCHEDCONST < ISTANBUL >
+    rule [SCHEDCONSTBerlin] SCHEDCONST < BERLIN > => SCHEDCONST < ISTANBUL >
       requires notBool ( SCHEDCONST ==K Gcoldsload
                   orBool SCHEDCONST ==K Gcoldaccountaccess
                   orBool SCHEDCONST ==K Gwarmstorageread
@@ -322,8 +323,8 @@ A `ScheduleConst` is a constant determined by the fee schedule.
                   orBool SCHEDCONST ==K Gaccesslistaddress
                        )
 
-    rule Ghasaccesslist << BERLIN >> => true
-    rule SCHEDFLAG      << BERLIN >> => SCHEDFLAG << ISTANBUL >>
+    rule [hasaccesslistBerlin] Ghasaccesslist << BERLIN >> => true
+    rule [SCHEDFLAGBerlin]     SCHEDFLAG      << BERLIN >> => SCHEDFLAG << ISTANBUL >>
       requires notBool ( SCHEDFLAG ==K Ghasaccesslist )
 ```
 
@@ -332,18 +333,18 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "LONDON" [symbol(LONDON_EVM), smtlib(schedule_LONDON)]
  // --------------------------------------------------------------------------
-    rule Rselfdestruct < LONDON > => 0
-    rule Rsstoreclear  < LONDON > => Gsstorereset < LONDON > +Int Gaccessliststoragekey < LONDON >
-    rule Rmaxquotient  < LONDON > => 5
-    rule SCHEDCONST    < LONDON > => SCHEDCONST < BERLIN >
+    rule [RselfdestructLondon] Rselfdestruct < LONDON > => 0
+    rule [RsstoreclearLondon]  Rsstoreclear  < LONDON > => Gsstorereset < LONDON > +Int Gaccessliststoragekey < LONDON >
+    rule [RmaxquotientLondon]  Rmaxquotient  < LONDON > => 5
+    rule [SCHEDCONSTLondon]    SCHEDCONST    < LONDON > => SCHEDCONST < BERLIN >
       requires notBool ( SCHEDCONST ==K Rselfdestruct
                   orBool SCHEDCONST ==K Rsstoreclear
                   orBool SCHEDCONST ==K Rmaxquotient
                        )
 
-    rule Ghasbasefee           << LONDON >> => true
-    rule Ghasrejectedfirstbyte << LONDON >> => true
-    rule SCHEDFLAG             << LONDON >> => SCHEDFLAG << BERLIN >>
+    rule [GhasbasefeeLondon]           Ghasbasefee           << LONDON >> => true
+    rule [GhasrejectedfirstbyteLondon] Ghasrejectedfirstbyte << LONDON >> => true
+    rule [SCHEDFLAGLondon]             SCHEDFLAG             << LONDON >> => SCHEDFLAG << BERLIN >>
       requires notBool ( SCHEDFLAG ==K Ghasbasefee
                   orBool SCHEDFLAG ==K Ghasrejectedfirstbyte
                        )
@@ -354,12 +355,12 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "MERGE" [symbol(MERGE_EVM), smtlib(schedule_MERGE)]
  // -----------------------------------------------------------------------
-    rule Rb         < MERGE > => 0
-    rule SCHEDCONST < MERGE > => SCHEDCONST < LONDON >
+    rule [RbMerge]         Rb         < MERGE > => 0
+    rule [SCHEDCONSTMerge] SCHEDCONST < MERGE > => SCHEDCONST < LONDON >
       requires notBool SCHEDCONST ==K Rb
 
-    rule Ghasprevrandao << MERGE >> => true
-    rule SCHEDFLAG      << MERGE >> => SCHEDFLAG << LONDON >>
+    rule [GhasprevrandaoMerge] Ghasprevrandao << MERGE >> => true
+    rule [SCHEDFLAGMerge]      SCHEDFLAG      << MERGE >> => SCHEDFLAG << LONDON >>
       requires notBool SCHEDFLAG ==K Ghasprevrandao
 ```
 
@@ -368,18 +369,18 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "SHANGHAI" [symbol(SHANGHAI_EVM), smtlib(schedule_SHANGHAI)]
  // --------------------------------------------------------------------------------
-    rule maxInitCodeSize   < SHANGHAI > => 2 *Int maxCodeSize < SHANGHAI >
-    rule Ginitcodewordcost < SHANGHAI > => 2
-    rule SCHEDCONST        < SHANGHAI > => SCHEDCONST < MERGE >
+    rule [maxInitCodeSizeShanghai]   maxInitCodeSize   < SHANGHAI > => 2 *Int maxCodeSize < SHANGHAI >
+    rule [GinitcodewordcostShanghai] Ginitcodewordcost < SHANGHAI > => 2
+    rule [SCHEDCONSTShanghai]        SCHEDCONST        < SHANGHAI > => SCHEDCONST < MERGE >
       requires notBool ( SCHEDCONST ==K maxInitCodeSize
                   orBool SCHEDCONST ==K Ginitcodewordcost
                        )
 
-    rule Ghasmaxinitcodesize << SHANGHAI >> => true
-    rule Ghaspushzero        << SHANGHAI >> => true
-    rule Ghaswarmcoinbase    << SHANGHAI >> => true
-    rule Ghaswithdrawals     << SHANGHAI >> => true
-    rule SCHEDFLAG           << SHANGHAI >> => SCHEDFLAG << MERGE >>
+    rule [GhasmaxinitcodesizeShanghai] Ghasmaxinitcodesize << SHANGHAI >> => true
+    rule [GhaspushzeroShanghai]        Ghaspushzero        << SHANGHAI >> => true
+    rule [GhaswarmcoinbaseShanghai]    Ghaswarmcoinbase    << SHANGHAI >> => true
+    rule [GhaswithdrawalsShanghai]     Ghaswithdrawals     << SHANGHAI >> => true
+    rule [SCHEDFLAGShanghai]           SCHEDFLAG           << SHANGHAI >> => SCHEDFLAG << MERGE >>
       requires notBool ( SCHEDFLAG ==K Ghasmaxinitcodesize
                   orBool SCHEDFLAG ==K Ghaspushzero
                   orBool SCHEDFLAG ==K Ghaswarmcoinbase
@@ -392,20 +393,20 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "CANCUN" [symbol(CANCUN_EVM), smtlib(schedule_CANCUN)]
  // --------------------------------------------------------------------------
-    rule Gwarmstoragedirtystore < CANCUN > => Gwarmstorageread < CANCUN >
-    rule Gpointeval             < CANCUN > => 50000
-    rule SCHEDCONST             < CANCUN > => SCHEDCONST < SHANGHAI >
+    rule [GwarmstoragedirtystoreCancun] Gwarmstoragedirtystore < CANCUN > => Gwarmstorageread < CANCUN >
+    rule [GpointevalCancun]             Gpointeval             < CANCUN > => 50000
+    rule [SCHEDCONSTCancun]             SCHEDCONST             < CANCUN > => SCHEDCONST < SHANGHAI >
       requires notBool ( SCHEDCONST ==K Gwarmstoragedirtystore
                   orBool SCHEDCONST ==K Gpointeval
                        )
 
-    rule Ghastransient   << CANCUN >> => true
-    rule Ghasmcopy       << CANCUN >> => true
-    rule Ghasbeaconroot  << CANCUN >> => true
-    rule Ghaseip6780     << CANCUN >> => true
-    rule Ghasblobbasefee << CANCUN >> => true
-    rule Ghasblobhash    << CANCUN >> => true
-    rule SCHEDFLAG       << CANCUN >> => SCHEDFLAG << SHANGHAI >>
+    rule [GhastransientCancun]   Ghastransient   << CANCUN >> => true
+    rule [GhasmcopyCancun]       Ghasmcopy       << CANCUN >> => true
+    rule [GhasbeaconrootCancun]  Ghasbeaconroot  << CANCUN >> => true
+    rule [Ghaseip6780Cancun]     Ghaseip6780     << CANCUN >> => true
+    rule [GhasblobbasefeeCancun] Ghasblobbasefee << CANCUN >> => true
+    rule [GhasblobhashCancun]    Ghasblobhash    << CANCUN >> => true
+    rule [SCHEDFLAGCancun]       SCHEDFLAG      << CANCUN >> => SCHEDFLAG << SHANGHAI >>
       requires notBool ( SCHEDFLAG ==K Ghastransient
                   orBool SCHEDFLAG ==K Ghasmcopy
                   orBool SCHEDFLAG ==K Ghasbeaconroot

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -57,105 +57,105 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "DEFAULT" [symbol(DEFAULT_EVM), smtlib(schedule_DEFAULT)]
  // -----------------------------------------------------------------------------
-    rule [GzeroDefault]    Gzero    < DEFAULT > => 0
-    rule [GbaseDefault]    Gbase    < DEFAULT > => 2
-    rule [GverylowDefault] Gverylow < DEFAULT > => 3
-    rule [GlowDefault]     Glow     < DEFAULT > => 5
-    rule [GmidDefault]     Gmid     < DEFAULT > => 8
-    rule [GhighDefault]    Ghigh    < DEFAULT > => 10
+    rule [GzeroDefault]:    Gzero    < DEFAULT > => 0
+    rule [GbaseDefault]:    Gbase    < DEFAULT > => 2
+    rule [GverylowDefault]: Gverylow < DEFAULT > => 3
+    rule [GlowDefault]:     Glow     < DEFAULT > => 5
+    rule [GmidDefault]:     Gmid     < DEFAULT > => 8
+    rule [GhighDefault]:    Ghigh    < DEFAULT > => 10
 
-    rule [GexpDefault]      Gexp      < DEFAULT > => 10
-    rule [GexpbyteDefault]  Gexpbyte  < DEFAULT > => 10
-    rule [Gsha3Default]     Gsha3     < DEFAULT > => 30
-    rule [Gsha3wordDefault] Gsha3word < DEFAULT > => 6
+    rule [GexpDefault]:      Gexp      < DEFAULT > => 10
+    rule [GexpbyteDefault]:  Gexpbyte  < DEFAULT > => 10
+    rule [Gsha3Default]:     Gsha3     < DEFAULT > => 30
+    rule [Gsha3wordDefault]: Gsha3word < DEFAULT > => 6
 
-    rule [GsloadDefault]       Gsload       < DEFAULT > => 50
-    rule [GsstoresetDefault]   Gsstoreset   < DEFAULT > => 20000
-    rule [GsstoreresetDefault] Gsstorereset < DEFAULT > => 5000
-    rule [RsstoreclearDefault] Rsstoreclear < DEFAULT > => 15000
+    rule [GsloadDefault]:       Gsload       < DEFAULT > => 50
+    rule [GsstoresetDefault]:   Gsstoreset   < DEFAULT > => 20000
+    rule [GsstoreresetDefault]: Gsstorereset < DEFAULT > => 5000
+    rule [RsstoreclearDefault]: Rsstoreclear < DEFAULT > => 15000
 
-    rule [GlogDefault]      Glog      < DEFAULT > => 375
-    rule [GlogdataDefault]  Glogdata  < DEFAULT > => 8
-    rule [GlogtopicDefault] Glogtopic < DEFAULT > => 375
+    rule [GlogDefault]:      Glog      < DEFAULT > => 375
+    rule [GlogdataDefault]:  Glogdata  < DEFAULT > => 8
+    rule [GlogtopicDefault]: Glogtopic < DEFAULT > => 375
 
-    rule [GcallDefault]        Gcall        < DEFAULT > => 40
-    rule [GcallstipendDefault] Gcallstipend < DEFAULT > => 2300
-    rule [GcallvalueDefault]   Gcallvalue   < DEFAULT > => 9000
-    rule [GnewaccountDefault]  Gnewaccount  < DEFAULT > => 25000
+    rule [GcallDefault]:        Gcall        < DEFAULT > => 40
+    rule [GcallstipendDefault]: Gcallstipend < DEFAULT > => 2300
+    rule [GcallvalueDefault]:   Gcallvalue   < DEFAULT > => 9000
+    rule [GnewaccountDefault]:  Gnewaccount  < DEFAULT > => 25000
 
-    rule [GcreateDefault]       Gcreate       < DEFAULT > => 32000
-    rule [GcodedepositDefault]  Gcodedeposit  < DEFAULT > => 200
-    rule [GselfdestructDefault] Gselfdestruct < DEFAULT > => 0
-    rule [RselfdestructDefault] Rselfdestruct < DEFAULT > => 24000
+    rule [GcreateDefault]:       Gcreate       < DEFAULT > => 32000
+    rule [GcodedepositDefault]:  Gcodedeposit  < DEFAULT > => 200
+    rule [GselfdestructDefault]: Gselfdestruct < DEFAULT > => 0
+    rule [RselfdestructDefault]: Rselfdestruct < DEFAULT > => 24000
 
-    rule [GmemoryDefault]      Gmemory      < DEFAULT > => 3
-    rule [GquadcoeffDefault]   Gquadcoeff   < DEFAULT > => 512
-    rule [GcopyDefault]        Gcopy        < DEFAULT > => 3
-    rule [GquaddivisorDefault] Gquaddivisor < DEFAULT > => 20
+    rule [GmemoryDefault]:      Gmemory      < DEFAULT > => 3
+    rule [GquadcoeffDefault]:   Gquadcoeff   < DEFAULT > => 512
+    rule [GcopyDefault]:        Gcopy        < DEFAULT > => 3
+    rule [GquaddivisorDefault]: Gquaddivisor < DEFAULT > => 20
 
-    rule [GtransactionDefault]   Gtransaction   < DEFAULT > => 21000
-    rule [GtxcreateDefault]      Gtxcreate      < DEFAULT > => 53000
-    rule [GtxdatazeroDefault]    Gtxdatazero    < DEFAULT > => 4
-    rule [GtxdatanonzeroDefault] Gtxdatanonzero < DEFAULT > => 68
+    rule [GtransactionDefault]:   Gtransaction   < DEFAULT > => 21000
+    rule [GtxcreateDefault]:      Gtxcreate      < DEFAULT > => 53000
+    rule [GtxdatazeroDefault]:    Gtxdatazero    < DEFAULT > => 4
+    rule [GtxdatanonzeroDefault]: Gtxdatanonzero < DEFAULT > => 68
 
-    rule [GjumpdestDefault]    Gjumpdest    < DEFAULT > => 1
-    rule [GbalanceDefault]     Gbalance     < DEFAULT > => 20
-    rule [GblockhashDefault]   Gblockhash   < DEFAULT > => 20
-    rule [GextcodesizeDefault] Gextcodesize < DEFAULT > => 20
-    rule [GextcodecopyDefault] Gextcodecopy < DEFAULT > => 20
+    rule [GjumpdestDefault]:    Gjumpdest    < DEFAULT > => 1
+    rule [GbalanceDefault]:     Gbalance     < DEFAULT > => 20
+    rule [GblockhashDefault]:   Gblockhash   < DEFAULT > => 20
+    rule [GextcodesizeDefault]: Gextcodesize < DEFAULT > => 20
+    rule [GextcodecopyDefault]: Gextcodecopy < DEFAULT > => 20
 
-    rule [GecaddDefault]       Gecadd       < DEFAULT > => 500
-    rule [GecmulDefault]       Gecmul       < DEFAULT > => 40000
-    rule [GecpairconstDefault] Gecpairconst < DEFAULT > => 100000
-    rule [GecpaircoeffDefault] Gecpaircoeff < DEFAULT > => 80000
-    rule [GfroundDefault]      Gfround      < DEFAULT > => 1
+    rule [GecaddDefault]:       Gecadd       < DEFAULT > => 500
+    rule [GecmulDefault]:       Gecmul       < DEFAULT > => 40000
+    rule [GecpairconstDefault]: Gecpairconst < DEFAULT > => 100000
+    rule [GecpaircoeffDefault]: Gecpaircoeff < DEFAULT > => 80000
+    rule [GfroundDefault]:      Gfround      < DEFAULT > => 1
 
-    rule [maxCodeSizeDefault] maxCodeSize < DEFAULT > => 2 ^Int 32 -Int 1
-    rule [RbDefault]          Rb          < DEFAULT > => 5 *Int (10 ^Int 18)
+    rule [maxCodeSizeDefault]: maxCodeSize < DEFAULT > => 2 ^Int 32 -Int 1
+    rule [RbDefault]:          Rb          < DEFAULT > => 5 *Int (10 ^Int 18)
 
-    rule [GcoldsloadDefault]             Gcoldsload             < DEFAULT > => 0
-    rule [GcoldaccountaccessDefault]     Gcoldaccountaccess     < DEFAULT > => 0
-    rule [GwarmstoragereadDefault]       Gwarmstorageread       < DEFAULT > => 0
-    rule [GwarmstoragedirtystoreDefault] Gwarmstoragedirtystore < DEFAULT > => 0
+    rule [GcoldsloadDefault]:             Gcoldsload             < DEFAULT > => 0
+    rule [GcoldaccountaccessDefault]:     Gcoldaccountaccess     < DEFAULT > => 0
+    rule [GwarmstoragereadDefault]:       Gwarmstorageread       < DEFAULT > => 0
+    rule [GwarmstoragedirtystoreDefault]: Gwarmstoragedirtystore < DEFAULT > => 0
 
-    rule [GpointevalDefault] Gpointeval < DEFAULT > => 0
+    rule [GpointevalDefault]: Gpointeval < DEFAULT > => 0
 
-    rule [GaccessliststoragekeyDefault] Gaccessliststoragekey < DEFAULT > => 0
-    rule [GaccesslistaddressDefault]    Gaccesslistaddress    < DEFAULT > => 0
+    rule [GaccessliststoragekeyDefault]: Gaccessliststoragekey < DEFAULT > => 0
+    rule [GaccesslistaddressDefault]:    Gaccesslistaddress    < DEFAULT > => 0
 
-    rule [maxInitCodeSizeDefault]   maxInitCodeSize   < DEFAULT > => 0
-    rule [GinitcodewordcostDefault] Ginitcodewordcost < DEFAULT > => 0
+    rule [maxInitCodeSizeDefault]:   maxInitCodeSize   < DEFAULT > => 0
+    rule [GinitcodewordcostDefault]: Ginitcodewordcost < DEFAULT > => 0
 
-    rule [RmaxquotientDefault] Rmaxquotient < DEFAULT > => 2
+    rule [RmaxquotientDefault]: Rmaxquotient < DEFAULT > => 2
 
-    rule [GselfdestructnewaccountDefault] Gselfdestructnewaccount << DEFAULT >> => false
-    rule [GstaticcalldepthDefault]        Gstaticcalldepth        << DEFAULT >> => true
-    rule [GemptyisnonexistentDefault]     Gemptyisnonexistent     << DEFAULT >> => false
-    rule [GzerovaluenewaccountgasDefault] Gzerovaluenewaccountgas << DEFAULT >> => true
-    rule [GhasrevertDefault]              Ghasrevert              << DEFAULT >> => false
-    rule [GhasreturndataDefault]          Ghasreturndata          << DEFAULT >> => false
-    rule [GhasstaticcallDefault]          Ghasstaticcall          << DEFAULT >> => false
-    rule [GhasshiftDefault]               Ghasshift               << DEFAULT >> => false
-    rule [GhasdirtysstoreDefault]         Ghasdirtysstore         << DEFAULT >> => false
-    rule [GhassstorestipendDefault]       Ghassstorestipend       << DEFAULT >> => false
-    rule [Ghascreate2Default]             Ghascreate2             << DEFAULT >> => false
-    rule [GhasextcodehashDefault]         Ghasextcodehash         << DEFAULT >> => false
-    rule [GhasselfbalanceDefault]         Ghasselfbalance         << DEFAULT >> => false
-    rule [GhaschainidDefault]             Ghaschainid             << DEFAULT >> => false
-    rule [GhasaccesslistDefault]          Ghasaccesslist          << DEFAULT >> => false
-    rule [GhasbasefeeDefault]             Ghasbasefee             << DEFAULT >> => false
-    rule [GhasblobbasefeeDefault]         Ghasblobbasefee         << DEFAULT >> => false
-    rule [GhasrejectedfirstbyteDefault]   Ghasrejectedfirstbyte   << DEFAULT >> => false
-    rule [GhasprevrandaoDefault]          Ghasprevrandao          << DEFAULT >> => false
-    rule [GhasmaxinitcodesizeDefault]     Ghasmaxinitcodesize     << DEFAULT >> => false
-    rule [GhaspushzeroDefault]            Ghaspushzero            << DEFAULT >> => false
-    rule [GhaswarmcoinbaseDefault]        Ghaswarmcoinbase        << DEFAULT >> => false
-    rule [GhaswithdrawalsDefault]         Ghaswithdrawals         << DEFAULT >> => false
-    rule [GhastransientDefault]           Ghastransient           << DEFAULT >> => false
-    rule [GhasmcopyDefault]               Ghasmcopy               << DEFAULT >> => false
-    rule [GhasbeaconrootDefault]          Ghasbeaconroot          << DEFAULT >> => false
-    rule [Ghaseip6780Default]             Ghaseip6780             << DEFAULT >> => false
-    rule [GhasblobhashDefault]            Ghasblobhash            << DEFAULT >> => false
+    rule [GselfdestructnewaccountDefault]: Gselfdestructnewaccount << DEFAULT >> => false
+    rule [GstaticcalldepthDefault]:        Gstaticcalldepth        << DEFAULT >> => true
+    rule [GemptyisnonexistentDefault]:     Gemptyisnonexistent     << DEFAULT >> => false
+    rule [GzerovaluenewaccountgasDefault]: Gzerovaluenewaccountgas << DEFAULT >> => true
+    rule [GhasrevertDefault]:              Ghasrevert              << DEFAULT >> => false
+    rule [GhasreturndataDefault]:          Ghasreturndata          << DEFAULT >> => false
+    rule [GhasstaticcallDefault]:          Ghasstaticcall          << DEFAULT >> => false
+    rule [GhasshiftDefault]:               Ghasshift               << DEFAULT >> => false
+    rule [GhasdirtysstoreDefault]:         Ghasdirtysstore         << DEFAULT >> => false
+    rule [GhassstorestipendDefault]:       Ghassstorestipend       << DEFAULT >> => false
+    rule [Ghascreate2Default]:             Ghascreate2             << DEFAULT >> => false
+    rule [GhasextcodehashDefault]:         Ghasextcodehash         << DEFAULT >> => false
+    rule [GhasselfbalanceDefault]:         Ghasselfbalance         << DEFAULT >> => false
+    rule [GhaschainidDefault]:             Ghaschainid             << DEFAULT >> => false
+    rule [GhasaccesslistDefault]:          Ghasaccesslist          << DEFAULT >> => false
+    rule [GhasbasefeeDefault]:             Ghasbasefee             << DEFAULT >> => false
+    rule [GhasblobbasefeeDefault]:         Ghasblobbasefee         << DEFAULT >> => false
+    rule [GhasrejectedfirstbyteDefault]:   Ghasrejectedfirstbyte   << DEFAULT >> => false
+    rule [GhasprevrandaoDefault]:          Ghasprevrandao          << DEFAULT >> => false
+    rule [GhasmaxinitcodesizeDefault]:     Ghasmaxinitcodesize     << DEFAULT >> => false
+    rule [GhaspushzeroDefault]:            Ghaspushzero            << DEFAULT >> => false
+    rule [GhaswarmcoinbaseDefault]:        Ghaswarmcoinbase        << DEFAULT >> => false
+    rule [GhaswithdrawalsDefault]:         Ghaswithdrawals         << DEFAULT >> => false
+    rule [GhastransientDefault]:           Ghastransient           << DEFAULT >> => false
+    rule [GhasmcopyDefault]:               Ghasmcopy               << DEFAULT >> => false
+    rule [GhasbeaconrootDefault]:          Ghasbeaconroot          << DEFAULT >> => false
+    rule [Ghaseip6780Default]:             Ghaseip6780             << DEFAULT >> => false
+    rule [GhasblobhashDefault]:            Ghasblobhash            << DEFAULT >> => false
 ```
 
 ### Frontier Schedule
@@ -163,10 +163,10 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "FRONTIER" [symbol(FRONTIER_EVM), smtlib(schedule_FRONTIER)]
  // --------------------------------------------------------------------------------
-    rule [GtxcreateFrontier]  Gtxcreate  < FRONTIER > => 21000
-    rule [SCHEDCONSTFrontier] SCHEDCONST < FRONTIER > => SCHEDCONST < DEFAULT > requires SCHEDCONST =/=K  Gtxcreate
+    rule [GtxcreateFrontier]:  Gtxcreate  < FRONTIER > => 21000
+    rule [SCHEDCONSTFrontier]: SCHEDCONST < FRONTIER > => SCHEDCONST < DEFAULT > requires SCHEDCONST =/=K  Gtxcreate
 
-    rule [SCHEDFLAGFrontier] SCHEDFLAG << FRONTIER >> => SCHEDFLAG << DEFAULT >>
+    rule [SCHEDFLAGFrontier]: SCHEDFLAG << FRONTIER >> => SCHEDFLAG << DEFAULT >>
 ```
 
 ### Homestead Schedule
@@ -174,9 +174,9 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "HOMESTEAD" [symbol(HOMESTEAD_EVM), smtlib(schedule_HOMESTEAD)]
  // -----------------------------------------------------------------------------------
-    rule [SCHEDCONSTHomestead] SCHEDCONST < HOMESTEAD > => SCHEDCONST < DEFAULT >
+    rule [SCHEDCONSTHomestead]: SCHEDCONST < HOMESTEAD > => SCHEDCONST < DEFAULT >
 
-    rule [SCHEDFLAGHomestead] SCHEDFLAG << HOMESTEAD >> => SCHEDFLAG << DEFAULT >>
+    rule [SCHEDFLAGHomestead]: SCHEDFLAG << HOMESTEAD >> => SCHEDFLAG << DEFAULT >>
 ```
 
 ### Tangerine Whistle Schedule
@@ -184,21 +184,21 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "TANGERINE_WHISTLE" [symbol(TANGERINE_WHISTLE_EVM), smtlib(schedule_TANGERINE_WHISTLE)]
  // -----------------------------------------------------------------------------------------------------------
-    rule [GbalanceTangerine]      Gbalance      < TANGERINE_WHISTLE > => 400
-    rule [GsloadTangerine]        Gsload        < TANGERINE_WHISTLE > => 200
-    rule [GcallTangerine]         Gcall         < TANGERINE_WHISTLE > => 700
-    rule [GselfdestructTangerine] Gselfdestruct < TANGERINE_WHISTLE > => 5000
-    rule [GextcodesizeTangerine]  Gextcodesize  < TANGERINE_WHISTLE > => 700
-    rule [GextcodecopyTangerine]  Gextcodecopy  < TANGERINE_WHISTLE > => 700
+    rule [GbalanceTangerine]:      Gbalance      < TANGERINE_WHISTLE > => 400
+    rule [GsloadTangerine]:        Gsload        < TANGERINE_WHISTLE > => 200
+    rule [GcallTangerine]:         Gcall         < TANGERINE_WHISTLE > => 700
+    rule [GselfdestructTangerine]: Gselfdestruct < TANGERINE_WHISTLE > => 5000
+    rule [GextcodesizeTangerine]:  Gextcodesize  < TANGERINE_WHISTLE > => 700
+    rule [GextcodecopyTangerine]:  Gextcodecopy  < TANGERINE_WHISTLE > => 700
 
-    rule [SCHEDCONSTTangerine] SCHEDCONST    < TANGERINE_WHISTLE > => SCHEDCONST < HOMESTEAD >
+    rule [SCHEDCONSTTangerine]: SCHEDCONST    < TANGERINE_WHISTLE > => SCHEDCONST < HOMESTEAD >
       requires notBool ( SCHEDCONST ==K Gbalance      orBool SCHEDCONST ==K Gsload       orBool SCHEDCONST ==K Gcall
                   orBool SCHEDCONST ==K Gselfdestruct orBool SCHEDCONST ==K Gextcodesize orBool SCHEDCONST ==K Gextcodecopy
                        )
 
-    rule [GselfdestructnewaccountTangerine]   Gselfdestructnewaccount << TANGERINE_WHISTLE >> => true
-    rule [GstaticcalldepthTangerine]          Gstaticcalldepth        << TANGERINE_WHISTLE >> => false
-    rule [SCHEDCONSTTangerine]                SCHEDCONST              << TANGERINE_WHISTLE >> => SCHEDCONST << HOMESTEAD >>
+    rule [GselfdestructnewaccountTangerine]:   Gselfdestructnewaccount << TANGERINE_WHISTLE >> => true
+    rule [GstaticcalldepthTangerine]:          Gstaticcalldepth        << TANGERINE_WHISTLE >> => false
+    rule [SCHEDFLAGTangerine]:                SCHEDCONST              << TANGERINE_WHISTLE >> => SCHEDCONST << HOMESTEAD >>
       requires notBool ( SCHEDCONST ==K  Gselfdestructnewaccount orBool SCHEDCONST ==K Gstaticcalldepth )
 ```
 
@@ -207,15 +207,15 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "SPURIOUS_DRAGON" [symbol(SPURIOUS_DRAGON_EVM), smtlib(schedule_SPURIOUS_DRAGON)]
  // -----------------------------------------------------------------------------------------------------
-    rule [GexpbyteDragon]    Gexpbyte    < SPURIOUS_DRAGON > => 50
-    rule [maxCodeSizeDragon] maxCodeSize < SPURIOUS_DRAGON > => 24576
+    rule [GexpbyteDragon]:    Gexpbyte    < SPURIOUS_DRAGON > => 50
+    rule [maxCodeSizeDragon]: maxCodeSize < SPURIOUS_DRAGON > => 24576
 
-    rule [SCHEDCONSTDragon] SCHEDCONST  < SPURIOUS_DRAGON > => SCHEDCONST < TANGERINE_WHISTLE >
+    rule [SCHEDCONSTDragon]: SCHEDCONST  < SPURIOUS_DRAGON > => SCHEDCONST < TANGERINE_WHISTLE >
       requires SCHEDCONST =/=K  Gexpbyte andBool SCHEDCONST =/=K maxCodeSize
 
-    rule [GemptyisnonexistentDragon]     Gemptyisnonexistent     << SPURIOUS_DRAGON >> => true
-    rule [GzerovaluenewaccountgasDragon] Gzerovaluenewaccountgas << SPURIOUS_DRAGON >> => false
-    rule [SCHEDCONSTDragon]              SCHEDCONST              << SPURIOUS_DRAGON >> => SCHEDCONST << TANGERINE_WHISTLE >>
+    rule [GemptyisnonexistentDragon]:     Gemptyisnonexistent     << SPURIOUS_DRAGON >> => true
+    rule [GzerovaluenewaccountgasDragon]: Gzerovaluenewaccountgas << SPURIOUS_DRAGON >> => false
+    rule [SCHEDFLAGDragon]:              SCHEDCONST              << SPURIOUS_DRAGON >> => SCHEDCONST << TANGERINE_WHISTLE >>
       requires notBool ( SCHEDCONST ==K  Gemptyisnonexistent orBool SCHEDCONST ==K Gzerovaluenewaccountgas )
 ```
 
@@ -224,14 +224,14 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "BYZANTIUM" [symbol(BYZANTIUM_EVM), smtlib(schedule_BYZANTIUM)]
  // -----------------------------------------------------------------------------------
-    rule [RbByzantium]      Rb         < BYZANTIUM > => 3 *Int eth
-    rule [SCHEDCONSTDragon] SCHEDCONST < BYZANTIUM > => SCHEDCONST < SPURIOUS_DRAGON >
+    rule [RbByzantium]:      Rb         < BYZANTIUM > => 3 *Int eth
+    rule [SCHEDCONSTByzantium]: SCHEDCONST < BYZANTIUM > => SCHEDCONST < SPURIOUS_DRAGON >
       requires notBool ( SCHEDCONST ==K Rb )
 
-    rule [GhasrevertDragon]     Ghasrevert     << BYZANTIUM >> => true
-    rule [GhasreturndataDragon] Ghasreturndata << BYZANTIUM >> => true
-    rule [GhasstaticcallDragon] Ghasstaticcall << BYZANTIUM >> => true
-    rule [SCHEDFLAGDragon]      SCHEDFLAG      << BYZANTIUM >> => SCHEDFLAG << SPURIOUS_DRAGON >>
+    rule [GhasrevertByzantium]:     Ghasrevert     << BYZANTIUM >> => true
+    rule [GhasreturndataByzantium]: Ghasreturndata << BYZANTIUM >> => true
+    rule [GhasstaticcallByzantium]: Ghasstaticcall << BYZANTIUM >> => true
+    rule [SCHEDFLAGByzantium]:      SCHEDFLAG      << BYZANTIUM >> => SCHEDFLAG << SPURIOUS_DRAGON >>
       requires notBool ( SCHEDFLAG ==K  Ghasrevert orBool SCHEDFLAG ==K Ghasreturndata orBool SCHEDFLAG ==K Ghasstaticcall )
 ```
 
@@ -240,15 +240,15 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "CONSTANTINOPLE" [symbol(CONSTANTINOPLE_EVM), smtlib(schedule_CONSTANTINOPLE)]
  // --------------------------------------------------------------------------------------------------
-    rule [RbConstantinople]         Rb         < CONSTANTINOPLE > => 2 *Int eth
-    rule [SCHEDCONSTConstantinople] SCHEDCONST < CONSTANTINOPLE > => SCHEDCONST < BYZANTIUM >
+    rule [RbConstantinople]:         Rb         < CONSTANTINOPLE > => 2 *Int eth
+    rule [SCHEDCONSTConstantinople]: SCHEDCONST < CONSTANTINOPLE > => SCHEDCONST < BYZANTIUM >
       requires notBool ( SCHEDCONST ==K Rb )
 
-    rule [GhasshiftConstantinople]       Ghasshift       << CONSTANTINOPLE >> => true
-    rule [GhasdirtysstoreConstantinople] Ghasdirtysstore << CONSTANTINOPLE >> => true
-    rule [Ghascreate2Constantinople]     Ghascreate2     << CONSTANTINOPLE >> => true
-    rule [GhasextcodehashConstantinople] Ghasextcodehash << CONSTANTINOPLE >> => true
-    rule [SCHEDFLAGConstantinople]       SCHEDFLAG       << CONSTANTINOPLE >> => SCHEDFLAG << BYZANTIUM >>
+    rule [GhasshiftConstantinople]:       Ghasshift       << CONSTANTINOPLE >> => true
+    rule [GhasdirtysstoreConstantinople]: Ghasdirtysstore << CONSTANTINOPLE >> => true
+    rule [Ghascreate2Constantinople]:     Ghascreate2     << CONSTANTINOPLE >> => true
+    rule [GhasextcodehashConstantinople]: Ghasextcodehash << CONSTANTINOPLE >> => true
+    rule [SCHEDFLAGConstantinople]:       SCHEDFLAG       << CONSTANTINOPLE >> => SCHEDFLAG << BYZANTIUM >>
       requires notBool ( SCHEDFLAG ==K   Ghasshift orBool SCHEDFLAG ==K Ghasdirtysstore orBool SCHEDFLAG ==K Ghascreate2 orBool SCHEDFLAG ==K Ghasextcodehash )
 ```
 
@@ -257,10 +257,10 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "PETERSBURG" [symbol(PETERSBURG_EVM), smtlib(schedule_PETERSBURG)]
  // --------------------------------------------------------------------------------------
-    rule [SCHEDCONSTPetersburg] SCHEDCONST < PETERSBURG > => SCHEDCONST < CONSTANTINOPLE >
+    rule [SCHEDCONSTPetersburg]: SCHEDCONST < PETERSBURG > => SCHEDCONST < CONSTANTINOPLE >
 
-    rule [GhasdirtysstorePetersburg] Ghasdirtysstore << PETERSBURG >> => false
-    rule [SCHEDFLAGPetersburg]       SCHEDFLAG       << PETERSBURG >> => SCHEDFLAG << CONSTANTINOPLE >>
+    rule [GhasdirtysstorePetersburg]: Ghasdirtysstore << PETERSBURG >> => false
+    rule [SCHEDFLAGPetersburg]:       SCHEDFLAG       << PETERSBURG >> => SCHEDFLAG << CONSTANTINOPLE >>
       requires notBool ( SCHEDFLAG ==K Ghasdirtysstore )
 ```
 
@@ -269,14 +269,14 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "ISTANBUL" [symbol(ISTANBUL_EVM), smtlib(schedule_ISTANBUL)]
  // --------------------------------------------------------------------------------
-    rule [GecaddIstanbul]         Gecadd         < ISTANBUL > => 150
-    rule [GecmulIstanbul]         Gecmul         < ISTANBUL > => 6000
-    rule [GecpairconstIstanbul]   Gecpairconst   < ISTANBUL > => 45000
-    rule [GecpaircoeffIstanbul]   Gecpaircoeff   < ISTANBUL > => 34000
-    rule [GtxdatanonzeroIstanbul] Gtxdatanonzero < ISTANBUL > => 16
-    rule [GsloadIstanbul]         Gsload         < ISTANBUL > => 800
-    rule [GbalanceIstanbul]       Gbalance       < ISTANBUL > => 700
-    rule [SCHEDCONSTIstanbul]     SCHEDCONST     < ISTANBUL > => SCHEDCONST < PETERSBURG >
+    rule [GecaddIstanbul]:         Gecadd         < ISTANBUL > => 150
+    rule [GecmulIstanbul]:         Gecmul         < ISTANBUL > => 6000
+    rule [GecpairconstIstanbul]:   Gecpairconst   < ISTANBUL > => 45000
+    rule [GecpaircoeffIstanbul]:   Gecpaircoeff   < ISTANBUL > => 34000
+    rule [GtxdatanonzeroIstanbul]: Gtxdatanonzero < ISTANBUL > => 16
+    rule [GsloadIstanbul]:         Gsload         < ISTANBUL > => 800
+    rule [GbalanceIstanbul]:       Gbalance       < ISTANBUL > => 700
+    rule [SCHEDCONSTIstanbul]:     SCHEDCONST     < ISTANBUL > => SCHEDCONST < PETERSBURG >
       requires notBool ( SCHEDCONST ==K Gecadd
                   orBool SCHEDCONST ==K Gecmul
                   orBool SCHEDCONST ==K Gecpairconst
@@ -286,11 +286,11 @@ A `ScheduleConst` is a constant determined by the fee schedule.
                   orBool SCHEDCONST ==K Gbalance
                        )
 
-    rule [GhasselfbalanceIstanbul]   Ghasselfbalance   << ISTANBUL >> => true
-    rule [GhasdirtysstoreIstanbul]   Ghasdirtysstore   << ISTANBUL >> => true
-    rule [GhassstorestipendIstanbul] Ghassstorestipend << ISTANBUL >> => true
-    rule [GhaschainidIstanbul]       Ghaschainid       << ISTANBUL >> => true
-    rule [SCHEDFLAGIstanbul]         SCHEDFLAG         << ISTANBUL >> => SCHEDFLAG << PETERSBURG >>
+    rule [GhasselfbalanceIstanbul]:   Ghasselfbalance   << ISTANBUL >> => true
+    rule [GhasdirtysstoreIstanbul]:   Ghasdirtysstore   << ISTANBUL >> => true
+    rule [GhassstorestipendIstanbul]: Ghassstorestipend << ISTANBUL >> => true
+    rule [GhaschainidIstanbul]:       Ghaschainid       << ISTANBUL >> => true
+    rule [SCHEDFLAGIstanbul]:         SCHEDFLAG         << ISTANBUL >> => SCHEDFLAG << PETERSBURG >>
       requires notBool ( SCHEDFLAG ==K Ghasselfbalance
                   orBool SCHEDFLAG ==K Ghasdirtysstore
                   orBool SCHEDFLAG ==K Ghassstorestipend
@@ -303,16 +303,16 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "BERLIN" [symbol(BERLIN_EVM), smtlib(schedule_BERLIN)]
  // --------------------------------------------------------------------------
-    rule [GcoldsloadBerlin]            Gcoldsload            < BERLIN > => 2100
-    rule [GcoldaccountaccessBerlin]    Gcoldaccountaccess    < BERLIN > => 2600
-    rule [GwarmstoragereadBerlin]      Gwarmstorageread      < BERLIN > => 100
-    rule [GsloadBerlin]                Gsload                < BERLIN > => Gwarmstorageread < BERLIN >
-    rule [GsstoreresetBerlin]          Gsstorereset          < BERLIN > => 5000 -Int Gcoldsload < BERLIN >
-    rule [GquaddivisorBerlin]          Gquaddivisor          < BERLIN > => 3
-    rule [GaccessliststoragekeyBerlin] Gaccessliststoragekey < BERLIN > => 1900
-    rule [GaccesslistaddressBerlin]    Gaccesslistaddress    < BERLIN > => 2400
+    rule [GcoldsloadBerlin]:            Gcoldsload            < BERLIN > => 2100
+    rule [GcoldaccountaccessBerlin]:    Gcoldaccountaccess    < BERLIN > => 2600
+    rule [GwarmstoragereadBerlin]:      Gwarmstorageread      < BERLIN > => 100
+    rule [GsloadBerlin]:                Gsload                < BERLIN > => Gwarmstorageread < BERLIN >
+    rule [GsstoreresetBerlin]:          Gsstorereset          < BERLIN > => 5000 -Int Gcoldsload < BERLIN >
+    rule [GquaddivisorBerlin]:          Gquaddivisor          < BERLIN > => 3
+    rule [GaccessliststoragekeyBerlin]: Gaccessliststoragekey < BERLIN > => 1900
+    rule [GaccesslistaddressBerlin]:    Gaccesslistaddress    < BERLIN > => 2400
 
-    rule [SCHEDCONSTBerlin] SCHEDCONST < BERLIN > => SCHEDCONST < ISTANBUL >
+    rule [SCHEDCONSTBerlin]: SCHEDCONST < BERLIN > => SCHEDCONST < ISTANBUL >
       requires notBool ( SCHEDCONST ==K Gcoldsload
                   orBool SCHEDCONST ==K Gcoldaccountaccess
                   orBool SCHEDCONST ==K Gwarmstorageread
@@ -323,8 +323,8 @@ A `ScheduleConst` is a constant determined by the fee schedule.
                   orBool SCHEDCONST ==K Gaccesslistaddress
                        )
 
-    rule [hasaccesslistBerlin] Ghasaccesslist << BERLIN >> => true
-    rule [SCHEDFLAGBerlin]     SCHEDFLAG      << BERLIN >> => SCHEDFLAG << ISTANBUL >>
+    rule [hasaccesslistBerlin]: Ghasaccesslist << BERLIN >> => true
+    rule [SCHEDFLAGBerlin]:     SCHEDFLAG      << BERLIN >> => SCHEDFLAG << ISTANBUL >>
       requires notBool ( SCHEDFLAG ==K Ghasaccesslist )
 ```
 
@@ -333,18 +333,18 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "LONDON" [symbol(LONDON_EVM), smtlib(schedule_LONDON)]
  // --------------------------------------------------------------------------
-    rule [RselfdestructLondon] Rselfdestruct < LONDON > => 0
-    rule [RsstoreclearLondon]  Rsstoreclear  < LONDON > => Gsstorereset < LONDON > +Int Gaccessliststoragekey < LONDON >
-    rule [RmaxquotientLondon]  Rmaxquotient  < LONDON > => 5
-    rule [SCHEDCONSTLondon]    SCHEDCONST    < LONDON > => SCHEDCONST < BERLIN >
+    rule [RselfdestructLondon]: Rselfdestruct < LONDON > => 0
+    rule [RsstoreclearLondon]:  Rsstoreclear  < LONDON > => Gsstorereset < LONDON > +Int Gaccessliststoragekey < LONDON >
+    rule [RmaxquotientLondon]:  Rmaxquotient  < LONDON > => 5
+    rule [SCHEDCONSTLondon]:    SCHEDCONST    < LONDON > => SCHEDCONST < BERLIN >
       requires notBool ( SCHEDCONST ==K Rselfdestruct
                   orBool SCHEDCONST ==K Rsstoreclear
                   orBool SCHEDCONST ==K Rmaxquotient
                        )
 
-    rule [GhasbasefeeLondon]           Ghasbasefee           << LONDON >> => true
-    rule [GhasrejectedfirstbyteLondon] Ghasrejectedfirstbyte << LONDON >> => true
-    rule [SCHEDFLAGLondon]             SCHEDFLAG             << LONDON >> => SCHEDFLAG << BERLIN >>
+    rule [GhasbasefeeLondon]:           Ghasbasefee           << LONDON >> => true
+    rule [GhasrejectedfirstbyteLondon]: Ghasrejectedfirstbyte << LONDON >> => true
+    rule [SCHEDFLAGLondon]:             SCHEDFLAG             << LONDON >> => SCHEDFLAG << BERLIN >>
       requires notBool ( SCHEDFLAG ==K Ghasbasefee
                   orBool SCHEDFLAG ==K Ghasrejectedfirstbyte
                        )
@@ -355,12 +355,12 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "MERGE" [symbol(MERGE_EVM), smtlib(schedule_MERGE)]
  // -----------------------------------------------------------------------
-    rule [RbMerge]         Rb         < MERGE > => 0
-    rule [SCHEDCONSTMerge] SCHEDCONST < MERGE > => SCHEDCONST < LONDON >
+    rule [RbMerge]:         Rb         < MERGE > => 0
+    rule [SCHEDCONSTMerge]: SCHEDCONST < MERGE > => SCHEDCONST < LONDON >
       requires notBool SCHEDCONST ==K Rb
 
-    rule [GhasprevrandaoMerge] Ghasprevrandao << MERGE >> => true
-    rule [SCHEDFLAGMerge]      SCHEDFLAG      << MERGE >> => SCHEDFLAG << LONDON >>
+    rule [GhasprevrandaoMerge]: Ghasprevrandao << MERGE >> => true
+    rule [SCHEDFLAGMerge]:      SCHEDFLAG      << MERGE >> => SCHEDFLAG << LONDON >>
       requires notBool SCHEDFLAG ==K Ghasprevrandao
 ```
 
@@ -369,18 +369,18 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "SHANGHAI" [symbol(SHANGHAI_EVM), smtlib(schedule_SHANGHAI)]
  // --------------------------------------------------------------------------------
-    rule [maxInitCodeSizeShanghai]   maxInitCodeSize   < SHANGHAI > => 2 *Int maxCodeSize < SHANGHAI >
-    rule [GinitcodewordcostShanghai] Ginitcodewordcost < SHANGHAI > => 2
-    rule [SCHEDCONSTShanghai]        SCHEDCONST        < SHANGHAI > => SCHEDCONST < MERGE >
+    rule [maxInitCodeSizeShanghai]:   maxInitCodeSize   < SHANGHAI > => 2 *Int maxCodeSize < SHANGHAI >
+    rule [GinitcodewordcostShanghai]: Ginitcodewordcost < SHANGHAI > => 2
+    rule [SCHEDCONSTShanghai]:        SCHEDCONST        < SHANGHAI > => SCHEDCONST < MERGE >
       requires notBool ( SCHEDCONST ==K maxInitCodeSize
                   orBool SCHEDCONST ==K Ginitcodewordcost
                        )
 
-    rule [GhasmaxinitcodesizeShanghai] Ghasmaxinitcodesize << SHANGHAI >> => true
-    rule [GhaspushzeroShanghai]        Ghaspushzero        << SHANGHAI >> => true
-    rule [GhaswarmcoinbaseShanghai]    Ghaswarmcoinbase    << SHANGHAI >> => true
-    rule [GhaswithdrawalsShanghai]     Ghaswithdrawals     << SHANGHAI >> => true
-    rule [SCHEDFLAGShanghai]           SCHEDFLAG           << SHANGHAI >> => SCHEDFLAG << MERGE >>
+    rule [GhasmaxinitcodesizeShanghai]: Ghasmaxinitcodesize << SHANGHAI >> => true
+    rule [GhaspushzeroShanghai]:        Ghaspushzero        << SHANGHAI >> => true
+    rule [GhaswarmcoinbaseShanghai]:    Ghaswarmcoinbase    << SHANGHAI >> => true
+    rule [GhaswithdrawalsShanghai]:     Ghaswithdrawals     << SHANGHAI >> => true
+    rule [SCHEDFLAGShanghai]:           SCHEDFLAG           << SHANGHAI >> => SCHEDFLAG << MERGE >>
       requires notBool ( SCHEDFLAG ==K Ghasmaxinitcodesize
                   orBool SCHEDFLAG ==K Ghaspushzero
                   orBool SCHEDFLAG ==K Ghaswarmcoinbase
@@ -393,20 +393,20 @@ A `ScheduleConst` is a constant determined by the fee schedule.
 ```k
     syntax Schedule ::= "CANCUN" [symbol(CANCUN_EVM), smtlib(schedule_CANCUN)]
  // --------------------------------------------------------------------------
-    rule [GwarmstoragedirtystoreCancun] Gwarmstoragedirtystore < CANCUN > => Gwarmstorageread < CANCUN >
-    rule [GpointevalCancun]             Gpointeval             < CANCUN > => 50000
-    rule [SCHEDCONSTCancun]             SCHEDCONST             < CANCUN > => SCHEDCONST < SHANGHAI >
+    rule [GwarmstoragedirtystoreCancun]: Gwarmstoragedirtystore < CANCUN > => Gwarmstorageread < CANCUN >
+    rule [GpointevalCancun]:             Gpointeval             < CANCUN > => 50000
+    rule [SCHEDCONSTCancun]:             SCHEDCONST             < CANCUN > => SCHEDCONST < SHANGHAI >
       requires notBool ( SCHEDCONST ==K Gwarmstoragedirtystore
                   orBool SCHEDCONST ==K Gpointeval
                        )
 
-    rule [GhastransientCancun]   Ghastransient   << CANCUN >> => true
-    rule [GhasmcopyCancun]       Ghasmcopy       << CANCUN >> => true
-    rule [GhasbeaconrootCancun]  Ghasbeaconroot  << CANCUN >> => true
-    rule [Ghaseip6780Cancun]     Ghaseip6780     << CANCUN >> => true
-    rule [GhasblobbasefeeCancun] Ghasblobbasefee << CANCUN >> => true
-    rule [GhasblobhashCancun]    Ghasblobhash    << CANCUN >> => true
-    rule [SCHEDFLAGCancun]       SCHEDFLAG      << CANCUN >> => SCHEDFLAG << SHANGHAI >>
+    rule [GhastransientCancun]:   Ghastransient   << CANCUN >> => true
+    rule [GhasmcopyCancun]:       Ghasmcopy       << CANCUN >> => true
+    rule [GhasbeaconrootCancun]:  Ghasbeaconroot  << CANCUN >> => true
+    rule [Ghaseip6780Cancun]:     Ghaseip6780     << CANCUN >> => true
+    rule [GhasblobbasefeeCancun]: Ghasblobbasefee << CANCUN >> => true
+    rule [GhasblobhashCancun]:    Ghasblobhash    << CANCUN >> => true
+    rule [SCHEDFLAGCancun]:       SCHEDFLAG      << CANCUN >> => SCHEDFLAG << SHANGHAI >>
       requires notBool ( SCHEDFLAG ==K Ghastransient
                   orBool SCHEDFLAG ==K Ghasmcopy
                   orBool SCHEDFLAG ==K Ghasbeaconroot

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -164,7 +164,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     syntax Schedule ::= "FRONTIER" [symbol(FRONTIER_EVM), smtlib(schedule_FRONTIER)]
  // --------------------------------------------------------------------------------
     rule [GtxcreateFrontier]:  Gtxcreate  < FRONTIER > => 21000
-    rule [SCHEDCONSTFrontier]: SCHEDCONST < FRONTIER > => SCHEDCONST < DEFAULT > requires SCHEDCONST =/=K  Gtxcreate
+    rule [SCHEDCONSTFrontier]: SCHEDCONST < FRONTIER > => SCHEDCONST < DEFAULT > requires SCHEDCONST =/=K Gtxcreate
 
     rule [SCHEDFLAGFrontier]: SCHEDFLAG << FRONTIER >> => SCHEDFLAG << DEFAULT >>
 ```

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -199,7 +199,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule [GselfdestructnewaccountTangerine]:   Gselfdestructnewaccount << TANGERINE_WHISTLE >> => true
     rule [GstaticcalldepthTangerine]:          Gstaticcalldepth        << TANGERINE_WHISTLE >> => false
     rule [SCHEDFLAGTangerine]:                 SCHEDFLAG               << TANGERINE_WHISTLE >> => SCHEDFLAG << HOMESTEAD >>
-      requires notBool ( SCHEDCONST ==K Gselfdestructnewaccount orBool SCHEDCONST ==K Gstaticcalldepth )
+      requires notBool ( SCHEDFLAG ==K Gselfdestructnewaccount orBool SCHEDFLAG ==K Gstaticcalldepth )
 ```
 
 ### Spurious Dragon Schedule
@@ -216,7 +216,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule [GemptyisnonexistentDragon]:     Gemptyisnonexistent     << SPURIOUS_DRAGON >> => true
     rule [GzerovaluenewaccountgasDragon]: Gzerovaluenewaccountgas << SPURIOUS_DRAGON >> => false
     rule [SCHEDFLAGDragon]:               SCHEDFLAG               << SPURIOUS_DRAGON >> => SCHEDFLAG << TANGERINE_WHISTLE >>
-      requires notBool ( SCHEDCONST ==K Gemptyisnonexistent orBool SCHEDCONST ==K Gzerovaluenewaccountgas )
+      requires notBool ( SCHEDFLAG ==K Gemptyisnonexistent orBool SCHEDFLAG ==K Gzerovaluenewaccountgas )
 ```
 
 ### Byzantium Schedule

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/schedule.md
@@ -199,7 +199,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule [GselfdestructnewaccountTangerine]:   Gselfdestructnewaccount << TANGERINE_WHISTLE >> => true
     rule [GstaticcalldepthTangerine]:          Gstaticcalldepth        << TANGERINE_WHISTLE >> => false
     rule [SCHEDFLAGTangerine]:                SCHEDCONST              << TANGERINE_WHISTLE >> => SCHEDCONST << HOMESTEAD >>
-      requires notBool ( SCHEDCONST ==K  Gselfdestructnewaccount orBool SCHEDCONST ==K Gstaticcalldepth )
+      requires notBool ( SCHEDCONST ==K Gselfdestructnewaccount orBool SCHEDCONST ==K Gstaticcalldepth )
 ```
 
 ### Spurious Dragon Schedule
@@ -211,12 +211,12 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule [maxCodeSizeDragon]: maxCodeSize < SPURIOUS_DRAGON > => 24576
 
     rule [SCHEDCONSTDragon]: SCHEDCONST  < SPURIOUS_DRAGON > => SCHEDCONST < TANGERINE_WHISTLE >
-      requires SCHEDCONST =/=K  Gexpbyte andBool SCHEDCONST =/=K maxCodeSize
+      requires SCHEDCONST =/=K Gexpbyte andBool SCHEDCONST =/=K maxCodeSize
 
     rule [GemptyisnonexistentDragon]:     Gemptyisnonexistent     << SPURIOUS_DRAGON >> => true
     rule [GzerovaluenewaccountgasDragon]: Gzerovaluenewaccountgas << SPURIOUS_DRAGON >> => false
     rule [SCHEDFLAGDragon]:              SCHEDCONST              << SPURIOUS_DRAGON >> => SCHEDCONST << TANGERINE_WHISTLE >>
-      requires notBool ( SCHEDCONST ==K  Gemptyisnonexistent orBool SCHEDCONST ==K Gzerovaluenewaccountgas )
+      requires notBool ( SCHEDCONST ==K Gemptyisnonexistent orBool SCHEDCONST ==K Gzerovaluenewaccountgas )
 ```
 
 ### Byzantium Schedule
@@ -232,7 +232,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule [GhasreturndataByzantium]: Ghasreturndata << BYZANTIUM >> => true
     rule [GhasstaticcallByzantium]: Ghasstaticcall << BYZANTIUM >> => true
     rule [SCHEDFLAGByzantium]:      SCHEDFLAG      << BYZANTIUM >> => SCHEDFLAG << SPURIOUS_DRAGON >>
-      requires notBool ( SCHEDFLAG ==K  Ghasrevert orBool SCHEDFLAG ==K Ghasreturndata orBool SCHEDFLAG ==K Ghasstaticcall )
+      requires notBool ( SCHEDFLAG ==K Ghasrevert orBool SCHEDFLAG ==K Ghasreturndata orBool SCHEDFLAG ==K Ghasstaticcall )
 ```
 
 ### Constantinople Schedule
@@ -249,7 +249,7 @@ A `ScheduleConst` is a constant determined by the fee schedule.
     rule [Ghascreate2Constantinople]:     Ghascreate2     << CONSTANTINOPLE >> => true
     rule [GhasextcodehashConstantinople]: Ghasextcodehash << CONSTANTINOPLE >> => true
     rule [SCHEDFLAGConstantinople]:       SCHEDFLAG       << CONSTANTINOPLE >> => SCHEDFLAG << BYZANTIUM >>
-      requires notBool ( SCHEDFLAG ==K   Ghasshift orBool SCHEDFLAG ==K Ghasdirtysstore orBool SCHEDFLAG ==K Ghascreate2 orBool SCHEDFLAG ==K Ghasextcodehash )
+      requires notBool ( SCHEDFLAG ==K Ghasshift orBool SCHEDFLAG ==K Ghasdirtysstore orBool SCHEDFLAG ==K Ghascreate2 orBool SCHEDFLAG ==K Ghasextcodehash )
 ```
 
 ### Petersburg Schedule


### PR DESCRIPTION
Unnamed rules result in more unfriendly Lean 4 generated code. This PR names those rules in `schedule.md` to change generated functions such as the following
![image](https://github.com/user-attachments/assets/da20fc0a-1ff0-462e-82c0-d07dc3ccfe7a)
to a more friendly version like
![image](https://github.com/user-attachments/assets/a24f21f5-603d-4349-8c5b-e3ffc6567ff3)

