### PR TITLE
Use the upstream `llvm_interpret` function

### DIFF
--- a/kevm-pyk/src/kevm_pyk/interpreter.py
+++ b/kevm-pyk/src/kevm_pyk/interpreter.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 from pyk.kdist import kdist
 from pyk.kore.parser import KoreParser
-from pyk.utils import run_process_2
+from pyk.ktool.krun import llvm_interpret_raw
 
 from .gst_to_kore import filter_gst_keys, gst_to_kore
 
@@ -16,21 +17,18 @@ if TYPE_CHECKING:
 
 
 def interpret(gst_data: Any, schedule: str, mode: str, chainid: int, usegas: bool, *, check: bool = True) -> Pattern:
-    proc_res = _interpret(gst_data, schedule, mode, chainid, usegas)
+    try:
+        res = _interpret(gst_data, schedule, mode, chainid, usegas, check)
+    except CalledProcessError as err:
+        raise RuntimeError(f'Interpreter failed with status {err.returncode}: {err.stderr}') from err
 
-    if check:
-        proc_res.check_returncode()
+    if res.stdout == '':
+        raise RuntimeError(f'Interpreter returned empty stdout: {res.stderr}')
 
-    if len(proc_res.stderr) > 0:
-        raise Exception(proc_res.stderr)
-
-    kore = KoreParser(proc_res.stdout).pattern()
-    return kore
+    return KoreParser(res.stdout).pattern()
 
 
-def _interpret(gst_data: Any, schedule: str, mode: str, chainid: int, usegas: bool) -> CompletedProcess:
+def _interpret(gst_data: Any, schedule: str, mode: str, chainid: int, usegas: bool, check: bool) -> CompletedProcess:
     gst_data_filtered = filter_gst_keys(gst_data)
-    interpreter = kdist.get('evm-semantics.llvm') / 'interpreter'
     init_kore = gst_to_kore(gst_data_filtered, schedule, mode, chainid, usegas)
-    proc_res = run_process_2([str(interpreter), '/dev/stdin', '-1', '/dev/stdout'], input=init_kore.text, check=False)
-    return proc_res
+    return llvm_interpret_raw(kdist.get('evm-semantics.llvm-summary'), init_kore.text, check=check)

--- a/kevm-pyk/src/kevm_pyk/interpreter.py
+++ b/kevm-pyk/src/kevm_pyk/interpreter.py
@@ -16,4 +16,4 @@ if TYPE_CHECKING:
 def interpret(gst_data: Any, schedule: str, mode: str, chainid: int, usegas: bool, *, check: bool = True) -> Pattern:
     """Interpret the given GST data using the LLVM backend."""
     init_kore = gst_to_kore(filter_gst_keys(gst_data), schedule, mode, chainid, usegas)
-    return llvm_interpret(kdist.get('evm-semantics.llvm-summary'), init_kore, check=check)
+    return llvm_interpret(kdist.get('evm-semantics.llvm'), init_kore, check=check)

--- a/kevm-pyk/src/kevm_pyk/interpreter.py
+++ b/kevm-pyk/src/kevm_pyk/interpreter.py
@@ -1,34 +1,19 @@
 from __future__ import annotations
 
-from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 from pyk.kdist import kdist
-from pyk.kore.parser import KoreParser
-from pyk.ktool.krun import llvm_interpret_raw
+from pyk.ktool.krun import llvm_interpret
 
 from .gst_to_kore import filter_gst_keys, gst_to_kore
 
 if TYPE_CHECKING:
-    from subprocess import CompletedProcess
     from typing import Any
 
     from pyk.kore.syntax import Pattern
 
 
 def interpret(gst_data: Any, schedule: str, mode: str, chainid: int, usegas: bool, *, check: bool = True) -> Pattern:
-    try:
-        res = _interpret(gst_data, schedule, mode, chainid, usegas, check)
-    except CalledProcessError as err:
-        raise RuntimeError(f'Interpreter failed with status {err.returncode}: {err.stderr}') from err
-
-    if res.stdout == '':
-        raise RuntimeError(f'Interpreter returned empty stdout: {res.stderr}')
-
-    return KoreParser(res.stdout).pattern()
-
-
-def _interpret(gst_data: Any, schedule: str, mode: str, chainid: int, usegas: bool, check: bool) -> CompletedProcess:
-    gst_data_filtered = filter_gst_keys(gst_data)
-    init_kore = gst_to_kore(gst_data_filtered, schedule, mode, chainid, usegas)
-    return llvm_interpret_raw(kdist.get('evm-semantics.llvm-summary'), init_kore.text, check=check)
+    """Interpret the given GST data using the LLVM backend."""
+    init_kore = gst_to_kore(filter_gst_keys(gst_data), schedule, mode, chainid, usegas)
+    return llvm_interpret(kdist.get('evm-semantics.llvm-summary'), init_kore, check=check)

--- a/kevm-pyk/src/kevm_pyk/interpreter.py
+++ b/kevm-pyk/src/kevm_pyk/interpreter.py
@@ -21,6 +21,9 @@ def interpret(gst_data: Any, schedule: str, mode: str, chainid: int, usegas: boo
     if check:
         proc_res.check_returncode()
 
+    if len(proc_res.stderr) > 0:
+        raise Exception(proc_res.stderr)
+
     kore = KoreParser(proc_res.stdout).pattern()
     return kore
 


### PR DESCRIPTION
- Simplified the `interpret` function by removing error handling for subprocess calls and directly utilizing `llvm_interpret`.
- Updated the `interpret` function to improve clarity and efficiency by integrating the filtering and conversion of GST data into a single line.
- Enhanced documentation to clarify the purpose of the `interpret` function.