### PR TITLE
Simplify the summary rules for `DUP`, `SWAP`, and `LOG`.

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kevm.py
+++ b/kevm-pyk/src/kevm_pyk/kevm.py
@@ -524,6 +524,10 @@ class KEVM(KProve, KRun):
         return KApply('lengthBytes(_)_BYTES-HOOKED_Int_Bytes', [ba])
 
     @staticmethod
+    def size_wordstack(ws: KInner) -> KApply:
+        return KApply('#sizeWordStack', [ws])
+
+    @staticmethod
     def inf_gas(g: KInner) -> KApply:
         return KApply('infGas', [g])
 

--- a/kevm-pyk/src/tests/integration/test_summarize.py
+++ b/kevm-pyk/src/tests/integration/test_summarize.py
@@ -10,13 +10,7 @@ def test_summarize(opcode: str) -> None:
     if get_summary_status(opcode) != 'PASSED':
         pytest.skip(f'{opcode} status: {OPCODES_SUMMARY_STATUS[opcode]}')
 
-    if opcode in ['DUP', 'SWAP', 'LOG']:
-        pytest.skip(f'{opcode} summarization is time-consuming')
-
-    print(f'[{opcode}] selected')
-    summarizer, proofs = summarize(opcode)
-    print(f'[{opcode}] summarize finished')
-    print(f'[{opcode}] {len(proofs)} proofs generated')
+    _, proofs = summarize(opcode)
 
     for proof in proofs:
         claims: list[KRuleLike] = []


### PR DESCRIPTION
- Introduced a new static method `size_wordstack` in the KEVM class to calculate the size of the word stack.
- Refactored the `stack_needed` function to return a single integer instead of a list, simplifying the logic for opcode stack size requirements.
- Updated the `build_spec` method in KEVMSummarizer to utilize the new `size_wordstack` method and adjusted constraints for specific opcodes (DUP, SWAP, LOG).
- Removed time-consuming opcode summarization skips in the test_summarize.py file to streamline testing.