### PR TITLE
Make cachix builds from CI/CD match CLI/flake inputs - Part 2, considering kevm-pyk as well

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,10 +60,9 @@
                   ".github/"
                   "result*"
                   "*.nix"
-                  "deps/"
                   "kevm-pyk/"
-                  # submodule directories are initilized empty by git, but
-                  # not included by nix flakes/nix CLI
+                  # do not include submodule directories that might be initilized empty or non-existent
+                  "/deps/"
                   "/tests/ethereum-tests"
                   "/web/k-web-theme"
                 ] ./.);
@@ -130,7 +129,13 @@
 
           kevm-pyk = poetry2nix.mkPoetryApplication {
             python = prev.python310;
-            projectDir = ./kevm-pyk;
+            projectDir = prev.lib.cleanSource (
+              prev.nix-gitignore.gitignoreSourcePure [
+                ./.gitignore
+                # do not include submodule directories that might be initilized empty or non-existent
+                "/src/kevm_pyk/kproj/plugin"
+              ] ./kevm-pyk/.
+            );
             overrides = poetry2nix.overrides.withDefaults
               (finalPython: prevPython: {
                 kframework = prev.pyk-python310;
@@ -204,8 +209,11 @@
               ".github/"
               "result*"
               "*.nix"
-              "deps/"
               "kevm-pyk/"
+              # do not include submodule directories that might be initilized empty or non-existent
+              "/deps/"
+              "/tests/ethereum-tests"
+              "/web/k-web-theme"
             ] ./.);
           };
 


### PR DESCRIPTION
This is a follow-up pull request for [Make cachix builds from CI/CD match CLI/flake inputs](https://github.com/runtimeverification/evm-semantics/pull/2739). Even after the pull request, I observed the same behaviour, where CI/CD builds and caches a build that does not match the hash requested by nix using the CLI.

During investigation, I found out that another empty git submodule directory causes this match, namely `/kevm-pyk/src/kevm_pyk/kproj/plugin` in the `kevm-pyk` derivation. This left me wondering as to why I didn't catch this, when building and matching the hash prior to publishing the last [pull request](https://github.com/runtimeverification/evm-semantics/pull/2739) in evm-semantics. Apparently, I mistakenly observed that the git submodule disappears, when built by nix CLI or as a nix flake input. In reality, the git submodule disappears on CI/CD. This is why my previous test built two matching hashes, while the hash still mismatched on CI/CD.

This pull request fixes the remaining git submodule cachix issues. I specifically took a look at all places, where sources are parsed in nix. Though, I cannot reliably test whether versions will actually match using local builds instead of building using the respective CI/CD [job](https://github.com/runtimeverification/evm-semantics/actions/runs/14523535337/job/40749807431#step:5:25).