### PR TITLE
Cachix workaround & push kevm to `k-framework-binary` cachix

### DIFF
--- a/.github/scripts/check-cachix-pin.sh
+++ b/.github/scripts/check-cachix-pin.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kup relies on cachix registry k-framework-binary.
+CACHE="k-framework-binary"
+OWNER_REPO="${OWNER_REPO:-$(git remote get-url origin | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')}"
+REV="${REV:-${GITHUB_SHA:-$(git rev-parse HEAD)}}"
+UNAME_S="$(uname -s)"
+UNAME_M="$(uname -m)"
+case "${UNAME_S}-${UNAME_M}" in
+  Linux-x86_64) SYSTEM="x86_64-linux" ;;
+  Linux-aarch64 | Linux-arm64) SYSTEM="aarch64-linux" ;;
+  Darwin-x86_64) SYSTEM="x86_64-darwin" ;;
+  Darwin-arm64) SYSTEM="aarch64-darwin" ;;
+  *)
+    echo "Unsupported platform: ${UNAME_S}-${UNAME_M}" >&2
+    exit 1
+    ;;
+esac
+PIN_API_URL="https://app.cachix.org/api/v1/cache/${CACHE}/pin"
+CHECK_PACKAGES=(kevm)
+
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+# Append to the GitHub step summary when set; always print to stdout for live job logs.
+summary_and_log() {
+  if [[ "${SUMMARY}" == "/dev/stdout" ]]; then
+    cat
+  else
+    tee -a "${SUMMARY}"
+  fi
+}
+
+{
+  echo "## Cachix Publish Summary"
+  echo "CACHE: $CACHE"
+  echo "OWNER_REPO: $OWNER_REPO"
+  echo "REV: $REV"
+  echo "SYSTEM: $SYSTEM"
+  echo "PACKAGES: ${CHECK_PACKAGES[*]}"
+} >> "$SUMMARY"
+
+# Verify push + pin together for each package. Both can become visible with delay.
+PIN_VISIBILITY_TIMEOUT_SECONDS=120 # 2 minutes
+PIN_VISIBILITY_INTERVAL_SECONDS=5  # 5 seconds
+PIN_VISIBILITY_ATTEMPTS=$((PIN_VISIBILITY_TIMEOUT_SECONDS / PIN_VISIBILITY_INTERVAL_SECONDS))
+for i in $(seq 1 "$PIN_VISIBILITY_ATTEMPTS"); do
+  PIN_JSON="$(curl -fsSL "${PIN_API_URL}?q=${REV}")"
+  ALL_OK=1
+
+  for PKG in "${CHECK_PACKAGES[@]}"; do
+    KEY="github:${OWNER_REPO}/${REV}#packages.${SYSTEM}.${PKG}"
+    STORE_PATH="$(
+      echo "$PIN_JSON" \
+        | jq -r --arg k "$KEY" 'map(select(.name == $k)) | first | (.lastRevision.storePath // .storePath // .store_path // .path // "")'
+    )"
+    if [ -z "$STORE_PATH" ]; then
+      PIN_STATUS="pin-missing"
+      PUSH_STATUS="000"
+      ALL_OK=0
+      {
+        echo "key-${PKG}: ${KEY}"
+        echo "pin-status-${PKG}: ${PIN_STATUS}"
+        echo "push-http-${PKG}: ${PUSH_STATUS}"
+      } | summary_and_log
+      continue
+    fi
+
+    PIN_STATUS="pin-ok"
+    HASH="$(basename "$STORE_PATH" | cut -d- -f1)"
+    PUSH_NARINFO_URL="https://${CACHE}.cachix.org/${HASH}.narinfo"
+    PUSH_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "$PUSH_NARINFO_URL")" || PUSH_STATUS="000"
+    if [ "$PUSH_STATUS" != "200" ]; then
+      ALL_OK=0
+    fi
+
+    {
+      echo "key-${PKG}: ${KEY}"
+      echo "store-path-${PKG}: ${STORE_PATH}"
+      echo "pin-status-${PKG}: ${PIN_STATUS}"
+      echo "push-http-${PKG}: ${PUSH_STATUS}"
+    } | summary_and_log
+  done
+
+  if [ "$ALL_OK" = "1" ]; then
+    echo "cachix-status: push-and-pin-ok-for-all-packages" >> "$SUMMARY"
+    exit 0
+  fi
+
+  RETRY_MSG="cachix-check-attempt-${i}: not-ready, retrying in ${PIN_VISIBILITY_INTERVAL_SECONDS}s"
+  printf '%s\n' "$RETRY_MSG" | summary_and_log
+  sleep "$PIN_VISIBILITY_INTERVAL_SECONDS"
+done
+
+echo "cachix-status: push-or-pin-missing-after-${PIN_VISIBILITY_TIMEOUT_SECONDS}s-for-at-least-one-package" >> "$SUMMARY"
+# Pin API bulk JSON goes to job logs only (step summary stays readable); helps if the response shape changes.
+echo "check-cachix-pin: raw Cachix pin API response (last fetch):" >&2
+echo "$PIN_JSON" >&2
+exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
   make-release:
     name: 'Cut Release'
     runs-on: ubuntu-latest
-    needs: [draft-release, nix-cache]
+    needs: [draft-release, nix-cache, nix-binary-cache]
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,6 @@ jobs:
       - name: 'Build KEVM'
         run: |
           GC_DONT_GC=1 nix build --extra-experimental-features 'nix-command flakes' --print-build-logs
-      - name: 'Test KEVM'
-        run: |
-          GC_DONT_GC=1 nix build --extra-experimental-features 'nix-command flakes' --print-build-logs .#kevm-test
       - name: 'Push KEVM dependencies to nix cache'
         uses: workflow/nix-shell-action@v3.0.3
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           script: |
             kevm=$(nix build --extra-experimental-features 'nix-command flakes' .#kevm --json | jq -r '.[].outputs | to_entries[].value')
             drv=$(nix-store --query --deriver ${kevm})
-            nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework
+            nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework || true
       - name: 'On failure, delete drafted release'
         if: failure()
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: 'Test KEVM'
         run: |
           GC_DONT_GC=1 nix build --extra-experimental-features 'nix-command flakes' --print-build-logs .#kevm-test
-      - name: 'Push KEVM'
+      - name: 'Push KEVM dependencies to nix cache'
         uses: workflow/nix-shell-action@v3.0.3
         env:
           GC_DONT_GC: 1
@@ -62,6 +62,55 @@ jobs:
             kevm=$(nix build --extra-experimental-features 'nix-command flakes' .#kevm --json | jq -r '.[].outputs | to_entries[].value')
             drv=$(nix-store --query --deriver ${kevm})
             nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework
+      - name: 'On failure, delete drafted release'
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          VERSION=v$(cat package/version)
+          gh release delete ${VERSION}                  \
+            --repo runtimeverification/evm-semantics  \
+            --yes                                       \
+            --cleanup-tag
+      - name: 'Post failure to channel'
+        if: failure()
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: "#kevm-notifications"
+          slack-message: "Failed to create KEVM release: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  nix-binary-cache:
+    name: 'Populate Nix Binary Cache'
+    strategy:
+      matrix:
+        include:
+          - runner: normal
+          - runner: ARM64
+    runs-on: ${{ matrix.runner }}
+    needs: draft-release
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.push.head.sha }}
+          fetch-depth: 0
+      - name: 'Publish KEVM to k-framework-binary cache'
+        uses: workflow/nix-shell-action@v3.0.3
+        env:
+          GC_DONT_GC: '1'
+          CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PRIVATE_KFB_TOKEN }}'
+          OWNER_REPO: '${{ github.repository }}'
+          REV: '${{ github.sha }}'
+        with:
+          packages: jq
+          script: |
+            export PATH="$(nix build github:runtimeverification/kup --no-link --json | jq -r '.[].outputs | to_entries[].value')/bin:$PATH"
+            kup publish k-framework-binary .#kevm --keep-days 180 || true
+            # Cachix has not been responding to 'cachix pin' requests made under the hood by kup. Verify the push and pin manually.
+            .github/scripts/check-cachix-pin.sh
       - name: 'On failure, delete drafted release'
         if: failure()
         env:


### PR DESCRIPTION
The kevm release workflow is failing when pushing to `k-framework` cachix using the cachix tool with the known cachix server error: https://github.com/runtimeverification/evm-semantics/actions/runs/24573697176/job/71853373954

This PR works around this by failing silently when pushing to that cache.

On top of that, apparently, the evm-semantics repository was not pushing and pinning `kevm` in the `k-framework-binary` cachix cache, which contains the binary builds of kevm. Therefore, I added a release workflow for that as well, including the workaround code that checks manually whether the push to cachix was successfully, as was added in other repositories as well.

Finally, I noticed that the release workflow tests KEVM even though this is already done in the test PR workflows. Henceforth, I removed this test from the release workflow as I wanted to keep the nix-cache and the new nix-binary-cache workflows consistent and similar without adding duplicated kevm testing effort.