### PR TITLE
lemmas: add bool2Word simplification for symbolic Bool expressions

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
@@ -29,8 +29,8 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
 ```k
     syntax Int ::= bool2Word ( Bool ) [symbol(bool2Word), function, total, injective, smtlib(bool2Word)]
  // ----------------------------------------------------------------------------------------------------
-    rule bool2Word( true  ) => 1
-    rule bool2Word( false ) => 0
+    rule bool2Word( B:Bool ) => 1 requires         B ==Bool true
+    rule bool2Word( B:Bool ) => 0 requires notBool B ==Bool true
 
     syntax Bool ::= word2Bool ( Int ) [symbol(word2Bool), function, total]
  // ----------------------------------------------------------------------

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm-types.md
@@ -29,8 +29,8 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
 ```k
     syntax Int ::= bool2Word ( Bool ) [symbol(bool2Word), function, total, injective, smtlib(bool2Word)]
  // ----------------------------------------------------------------------------------------------------
-    rule bool2Word( B:Bool ) => 1 requires         B ==Bool true
-    rule bool2Word( B:Bool ) => 0 requires notBool B ==Bool true
+    rule bool2Word( true  ) => 1
+    rule bool2Word( false ) => 0
 
     syntax Bool ::= word2Bool ( Int ) [symbol(word2Bool), function, total]
  // ----------------------------------------------------------------------

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
@@ -59,6 +59,14 @@ module LEMMAS-WITHOUT-SLOT-UPDATES [symbolic]
   // bool2Word reasoning
   // ########################
 
+    // Direct reduction via the path condition. The function rules in
+    // evm-types.md pattern-match on `true`/`false` and so do not fire when
+    // the argument is a symbolic Bool expression that the path condition
+    // only implies. These lemmas move the decision to a side condition,
+    // which Kore discharges against the full path condition (with SMT).
+    rule [b2w-true]:  bool2Word(B) => 1 requires         B [simplification]
+    rule [b2w-false]: bool2Word(B) => 0 requires notBool B [simplification]
+
     // Range
     rule [b2w-lb]: 0 <=Int bool2Word(_)         => true [simplification, smt-lemma]
     rule [b2w-ub]:         bool2Word(_) <=Int 1 => true [simplification, smt-lemma]

--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/lemmas/lemmas.k
@@ -59,11 +59,7 @@ module LEMMAS-WITHOUT-SLOT-UPDATES [symbolic]
   // bool2Word reasoning
   // ########################
 
-    // Direct reduction via the path condition. The function rules in
-    // evm-types.md pattern-match on `true`/`false` and so do not fire when
-    // the argument is a symbolic Bool expression that the path condition
-    // only implies. These lemmas move the decision to a side condition,
-    // which Kore discharges against the full path condition (with SMT).
+    // Reduce when the path condition only implies the argument.
     rule [b2w-true]:  bool2Word(B) => 1 requires         B [simplification]
     rule [b2w-false]: bool2Word(B) => 0 requires notBool B [simplification]
 

--- a/kevm-pyk/src/tests/integration/test_prove.py
+++ b/kevm-pyk/src/tests/integration/test_prove.py
@@ -110,6 +110,7 @@ KOMPILE_MAIN_FILE: Final = {
     'functional/lemmas-no-smt-spec.k': 'lemmas-no-smt-spec.k',
     'functional/lemmas-spec.k': 'lemmas-spec.k',
     'functional/abi-spec.k': 'abi-spec.k',
+    'functional/bool2Word-symbolic-spec.k': 'bool2Word-symbolic-spec.k',
     'functional/merkle-spec.k': 'merkle-spec.k',
     'functional/slot-updates-spec.k': 'slot-updates-spec.k',
     'functional/storageRoot-spec.k': 'storageRoot-spec.k',

--- a/tests/specs/functional/bool2Word-symbolic-spec.k
+++ b/tests/specs/functional/bool2Word-symbolic-spec.k
@@ -15,9 +15,10 @@ module VERIFICATION
 
 endmodule
 
-// Claims 5-6 fail under the legacy `bool2Word(true) => 1` rules: the path
-// condition implies but does not equate the argument, so the argument-position
-// matcher cannot discharge it without SMT. Side-conditioned rules pass them.
+// Without the `b2w-true` / `b2w-false` simplification lemmas in lemmas.k,
+// claims 5-6 fail: the path condition implies but does not equate the
+// argument, so the function-rule matcher cannot discharge it without SMT.
+// With the simplification lemmas, all six claims pass.
 module BOOL2WORD-SYMBOLIC-SPEC
     imports VERIFICATION
 

--- a/tests/specs/functional/bool2Word-symbolic-spec.k
+++ b/tests/specs/functional/bool2Word-symbolic-spec.k
@@ -1,0 +1,79 @@
+requires "edsl.md"
+requires "lemmas/lemmas.k"
+
+module VERIFICATION
+    imports EDSL
+    imports LEMMAS
+
+    syntax StepSort ::= Int | Bool
+ // ------------------------------
+
+    syntax KItem ::= runLemma ( StepSort ) [symbol(runLemma)]
+                   | doneLemma( StepSort )
+ // --------------------------------------
+    rule runLemma( T ) => doneLemma( T )
+
+endmodule
+
+//
+// Regression tests for symbolic-argument reasoning over bool2Word.
+//
+// Each of these claims sends a `bool2Word( <Bool expr> )` term whose
+// argument is a *Bool expression* (not the literal `true`/`false`)
+// and whose path condition entails — but is not syntactically equal to —
+// that expression. The claim asserts the term reduces to 0/1.
+//
+// Under the legacy rules
+//     rule bool2Word( true  ) => 1
+//     rule bool2Word( false ) => 0
+// pattern matching on the argument position does NOT consult the path
+// condition / SMT, so symbolic Bool expressions that the path condition
+// only *implies* (not equates to true/false) leave bool2Word(_) un-reduced
+// and the implication check at the end fails.
+//
+// Under the side-conditioned rules
+//     rule bool2Word( B ) => 1 requires         B ==Bool true
+//     rule bool2Word( B ) => 0 requires notBool B ==Bool true
+// the matcher binds B unconditionally and the side condition is discharged
+// by Kore's full path-condition + SMT reasoning, so these claims pass.
+//
+module BOOL2WORD-SYMBOLIC-SPEC
+    imports VERIFICATION
+
+    // Free Bool variable, path condition equates it to true/false.
+    // Both rule forms handle this — Kore canonicalizes `requires B`
+    // into substitution B |-> true before reaching bool2Word.
+    claim [b2w-var-true]:
+        <k> runLemma ( bool2Word(B:Bool) ) => doneLemma( 1 ) ... </k>
+        requires B
+
+    claim [b2w-var-false]:
+        <k> runLemma ( bool2Word(B:Bool) ) => doneLemma( 0 ) ... </k>
+        requires notBool B
+
+    // Argument is a Bool expression directly equated to itself in the
+    // path condition. Original rules also pass because Kore can rewrite
+    // the goal via the equality.
+    claim [b2w-expr-eq-true]:
+        <k> runLemma ( bool2Word(X >Int Y) ) => doneLemma( 1 ) ... </k>
+        requires X >Int Y
+
+    claim [b2w-expr-eq-false]:
+        <k> runLemma ( bool2Word(X >Int Y) ) => doneLemma( 0 ) ... </k>
+        requires notBool (X >Int Y)
+
+    // Path condition IMPLIES the argument, but is not syntactically equal
+    // to it: `X >Int 0` strictly implies `X >=Int 0`.
+    // Original rules FAIL this — pattern-match on `true` in argument
+    // position does not invoke SMT to discharge `X >=Int 0` under
+    // path condition `X >Int 0`.
+    // Side-conditioned rules PASS this — the side condition is checked
+    // against the full path condition.
+    claim [b2w-implied-true]:
+        <k> runLemma ( bool2Word(X >=Int 0) ) => doneLemma( 1 ) ... </k>
+        requires X >Int 0
+
+    claim [b2w-implied-false]:
+        <k> runLemma ( bool2Word(X <Int 0) ) => doneLemma( 0 ) ... </k>
+        requires X >Int 0
+endmodule

--- a/tests/specs/functional/bool2Word-symbolic-spec.k
+++ b/tests/specs/functional/bool2Word-symbolic-spec.k
@@ -15,34 +15,12 @@ module VERIFICATION
 
 endmodule
 
-//
-// Regression tests for symbolic-argument reasoning over bool2Word.
-//
-// Each of these claims sends a `bool2Word( <Bool expr> )` term whose
-// argument is a *Bool expression* (not the literal `true`/`false`)
-// and whose path condition entails — but is not syntactically equal to —
-// that expression. The claim asserts the term reduces to 0/1.
-//
-// Under the legacy rules
-//     rule bool2Word( true  ) => 1
-//     rule bool2Word( false ) => 0
-// pattern matching on the argument position does NOT consult the path
-// condition / SMT, so symbolic Bool expressions that the path condition
-// only *implies* (not equates to true/false) leave bool2Word(_) un-reduced
-// and the implication check at the end fails.
-//
-// Under the side-conditioned rules
-//     rule bool2Word( B ) => 1 requires         B ==Bool true
-//     rule bool2Word( B ) => 0 requires notBool B ==Bool true
-// the matcher binds B unconditionally and the side condition is discharged
-// by Kore's full path-condition + SMT reasoning, so these claims pass.
-//
+// Claims 5-6 fail under the legacy `bool2Word(true) => 1` rules: the path
+// condition implies but does not equate the argument, so the argument-position
+// matcher cannot discharge it without SMT. Side-conditioned rules pass them.
 module BOOL2WORD-SYMBOLIC-SPEC
     imports VERIFICATION
 
-    // Free Bool variable, path condition equates it to true/false.
-    // Both rule forms handle this — Kore canonicalizes `requires B`
-    // into substitution B |-> true before reaching bool2Word.
     claim [b2w-var-true]:
         <k> runLemma ( bool2Word(B:Bool) ) => doneLemma( 1 ) ... </k>
         requires B
@@ -51,9 +29,6 @@ module BOOL2WORD-SYMBOLIC-SPEC
         <k> runLemma ( bool2Word(B:Bool) ) => doneLemma( 0 ) ... </k>
         requires notBool B
 
-    // Argument is a Bool expression directly equated to itself in the
-    // path condition. Original rules also pass because Kore can rewrite
-    // the goal via the equality.
     claim [b2w-expr-eq-true]:
         <k> runLemma ( bool2Word(X >Int Y) ) => doneLemma( 1 ) ... </k>
         requires X >Int Y
@@ -62,13 +37,6 @@ module BOOL2WORD-SYMBOLIC-SPEC
         <k> runLemma ( bool2Word(X >Int Y) ) => doneLemma( 0 ) ... </k>
         requires notBool (X >Int Y)
 
-    // Path condition IMPLIES the argument, but is not syntactically equal
-    // to it: `X >Int 0` strictly implies `X >=Int 0`.
-    // Original rules FAIL this — pattern-match on `true` in argument
-    // position does not invoke SMT to discharge `X >=Int 0` under
-    // path condition `X >Int 0`.
-    // Side-conditioned rules PASS this — the side condition is checked
-    // against the full path condition.
     claim [b2w-implied-true]:
         <k> runLemma ( bool2Word(X >=Int 0) ) => doneLemma( 1 ) ... </k>
         requires X >Int 0


### PR DESCRIPTION
Add two `[simplification]` lemmas in `lemmas/lemmas.k` so that
`bool2Word(B)` reduces when the path condition implies `B` but does not
syntactically equate it. The function rules in `evm-types.md` are
unchanged — concrete inputs still take the original zero-overhead path.

```
rule [b2w-true]:  bool2Word(B) => 1 requires         B [simplification]
rule [b2w-false]: bool2Word(B) => 0 requires notBool B [simplification]
```

In Kore, the existing function rules pattern-match on `true`/`false` in
the argument position, which only runs the simplifier (no SMT against
the path condition). The new simplification lemmas bind `B`
unconditionally and discharge the side condition with the full path
condition, so a goal like `bool2Word(X >=Int 0) => 1` under path
condition `X >Int 0` now reduces.

### Tests

`tests/specs/functional/bool2Word-symbolic-spec.k` pins this with 6
claims:

| # | argument | path condition | without lemmas | with lemmas |
|---|---|---|---|---|
| 1 | `B` | `B` | pass | pass |
| 2 | `B` | `notBool B` | pass | pass |
| 3 | `X >Int Y` | `X >Int Y` | pass | pass |
| 4 | `X >Int Y` | `notBool (X >Int Y)` | pass | pass |
| 5 | `X >=Int 0` | `X >Int 0` | **stuck** | pass |
| 6 | `X <Int 0` | `X >Int 0` | **stuck** | pass |

## History

The original commits on this branch modified the `bool2Word` function
rules in `evm-types.md` directly. Per @ehildenb's review feedback,
switched to the `[simplification]` lemma approach — equivalent on this
spec, less invasive, opt-in via `imports LEMMAS`.

## Test plan

- [ ] `make test-prove-functional` (in particular `lemmas-spec.k`
  regressions — many existing `bool2Word` lemmas live next to the new
  ones)
- [ ] `make test-prove-rules` / `test-prove-optimizations`
- [ ] Conformance smoke

Draft pending full suite run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
