### PR TITLE
kevm-pyk: add `per_depth_timeout` to `run_prover` for progressive depth halving

### DIFF
--- a/kevm-pyk/src/kevm_pyk/utils.py
+++ b/kevm-pyk/src/kevm_pyk/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -45,6 +46,10 @@ if TYPE_CHECKING:
     T2 = TypeVar('T2')
 
 _LOGGER: Final = logging.getLogger(__name__)
+
+
+class _ProgressiveTimeout(Exception):
+    pass
 
 
 def claim_dependency_dict(claims: Iterable[KClaim], spec_module_name: str | None = None) -> dict[str, list[str]]:
@@ -117,6 +122,7 @@ def run_prover(
     assume_defined: bool = False,
     extra_module: KFlatModule | None = None,
     optimize_kcfg: bool = False,
+    per_depth_timeout: int = 0,
 ) -> bool:
     prover: APRProver | ImpliesProver
     try:
@@ -140,25 +146,45 @@ def run_prover(
                 if progress is not None and task_id is not None:
                     progress.update(task_id, summary=_proof.one_line_summary)
 
-            if force_sequential:
-                prover = create_prover()
-                prover.advance_proof(
-                    proof=proof,
-                    max_iterations=max_iterations,
-                    fail_fast=fail_fast,
-                    callback=update_status_bar,
-                    maintenance_rate=maintenance_rate,
-                )
-            else:
-                parallel_advance_proof(
-                    proof=proof,
-                    create_prover=create_prover,
-                    max_iterations=max_iterations,
-                    fail_fast=fail_fast,
-                    max_workers=max_frontier_parallel,
-                    callback=update_status_bar,
-                    maintenance_rate=maintenance_rate,
-                )
+            attempt_start = time.time()
+            budget_s: int | None = max_depth * per_depth_timeout if per_depth_timeout > 0 else None
+
+            def maintenance_callback(_proof: Proof) -> None:
+                update_status_bar(_proof)
+                if budget_s is not None and time.time() - attempt_start > budget_s:
+                    raise _ProgressiveTimeout()
+
+            while True:
+                try:
+                    if force_sequential:
+                        prover = create_prover()
+                        prover.advance_proof(
+                            proof=proof,
+                            max_iterations=max_iterations,
+                            fail_fast=fail_fast,
+                            callback=maintenance_callback,
+                            maintenance_rate=maintenance_rate,
+                        )
+                    else:
+                        parallel_advance_proof(
+                            proof=proof,
+                            create_prover=create_prover,
+                            max_iterations=max_iterations,
+                            fail_fast=fail_fast,
+                            max_workers=max_frontier_parallel,
+                            callback=maintenance_callback,
+                            maintenance_rate=maintenance_rate,
+                        )
+                    break
+                except _ProgressiveTimeout:
+                    _LOGGER.warning(
+                        f'Proof {proof.id}: depth={max_depth} attempt exhausted {budget_s}s budget; halving.'
+                    )
+                    if max_depth <= 1:
+                        break
+                    max_depth = max(1, max_depth // 2)
+                    attempt_start = time.time()
+                    budget_s = max_depth * per_depth_timeout
 
         elif type(proof) is EqualityProof:
             prover = ImpliesProver(proof, kcfg_explore=create_kcfg_explore(), assume_defined=assume_defined)


### PR DESCRIPTION
## Summary

Adds a new `per_depth_timeout: int = 0` parameter to `run_prover`. When set, each APRProof advance attempt is given a wall-clock budget of `current_depth * per_depth_timeout` seconds. If the budget is exhausted, `execute_depth` is halved (floor 1) and the proof resumes from the disk-persisted KCFG state, repeating down to `depth = 1`. Default `0` keeps the prior behavior — a single attempt at `max_depth`, no timeout.

Example: `run_prover(proof, ..., max_depth=1000, per_depth_timeout=10)` runs `1000 @ 10000s → 500 @ 5000s → ... → 1 @ 10s`.

## Why

A proof can stall when `execute_depth` is too coarse to cut at the next branch or terminal point. Halving the depth makes each step shorter and more interruptible, giving the prover more chances to find branch points without changing proof semantics — the saved KCFG carries over between attempts.

Downstream tools (kontrol, kasmer, kmir, etc.) all wrap `run_prover`; centralizing the policy here means every caller gets it via one option.

## Implementation

- New `per_depth_timeout` keyword argument (default `0`, off — fully backward-compatible).
- The APRProof branch is wrapped in a `while True:` retry loop. Each iteration:
  - Computes `budget_s = current_depth * per_depth_timeout` (or `None` when disabled).
  - Defines `maintenance_callback(_proof, _start, _budget)` (defaults bound to avoid late-binding) which calls the existing status-bar update and raises `_ProgressiveTimeout` when wall-clock exceeds `_budget`. With `_budget = None` the callback is a no-op beyond the status update — single-attempt semantics for `per_depth_timeout=0`.
  - Builds `APRProver` / `parallel_advance_proof` with that callback. `advance_proof` and `parallel_advance_proof` both invoke the callback *after* `proof.write_proof_data()`, so on-disk KCFG state is always current when the callback fires.
  - On `_ProgressiveTimeout`: logs the halving (`depth=N attempt exhausted Ms budget; halving.`), halves `current_depth` (floor 1), continues. On `depth=1` timeout we break out.
  - On any other exception: propagates to the outer `try/except Exception` and stored in `proof.error_info` as before.
- The unwind on timeout exits `parallel_advance_proof` cleanly: its internal `with _ProverPool(...)` runs `shutdown(wait=True)` so worker threads drain, no orphan workers.
- EqualityProof path is unchanged (no `max_depth` notion there).

## Test plan

- [x] `make check` clean (flake8, mypy, autoflake, isort, black).
- [x] `make test-unit` — 21/21 pass.
- [ ] Downstream smoke: kontrol with `per_depth_timeout=0` (default) must produce identical results to today.
- [ ] Downstream behavior: kontrol with `--per-depth-timeout 10` on a contrived stalling proof exhibits halving logs and eventual completion at a smaller depth.

## Downstream

A kontrol PR ([runtimeverification/kontrol#1141](https://github.com/runtimeverification/kontrol/pull/1141)) consumes this parameter to add a `--per-depth-timeout` CLI option to `kontrol prove`. That PR currently inlines a copy of the retry logic; once this lands and kontrol bumps `deps/kevm_release`, the inlined logic will be replaced by a single kwarg passed to `run_prover`.