### PR TITLE
Build KEVM once per architecture in release, populate both nix caches from it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
   nix-cache:
-    name: 'Populate Nix Cache'
+    name: 'Populate Nix Caches'
     strategy:
       matrix:
         include:
@@ -59,41 +59,6 @@ jobs:
             kevm=$(nix build --extra-experimental-features 'nix-command flakes' .#kevm --json | jq -r '.[].outputs | to_entries[].value')
             drv=$(nix-store --query --deriver ${kevm})
             nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework || true
-      - name: 'On failure, delete drafted release'
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -x
-          VERSION=v$(cat package/version)
-          gh release delete ${VERSION}                  \
-            --repo runtimeverification/evm-semantics  \
-            --yes                                       \
-            --cleanup-tag
-      - name: 'Post failure to channel'
-        if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
-        with:
-          channel-id: "#kevm-notifications"
-          slack-message: "Failed to create KEVM release: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        env:
-            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-
-  nix-binary-cache:
-    name: 'Populate Nix Binary Cache'
-    strategy:
-      matrix:
-        include:
-          - runner: normal
-          - runner: ARM64
-    runs-on: ${{ matrix.runner }}
-    needs: draft-release
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.push.head.sha }}
-          fetch-depth: 0
       - name: 'Publish KEVM to k-framework-binary cache'
         uses: workflow/nix-shell-action@v3.0.3
         env:
@@ -131,7 +96,7 @@ jobs:
   make-release:
     name: 'Cut Release'
     runs-on: ubuntu-latest
-    needs: [draft-release, nix-cache, nix-binary-cache]
+    needs: [draft-release, nix-cache]
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4


### PR DESCRIPTION
Same idea as: https://github.com/runtimeverification/k/pull/4927

The release workflow had two separate jobs — `nix-cache` ("Populate Nix Cache") and `nix-binary-cache` ("Populate Nix Binary Cache") — that each independently built KEVM on a `normal` + `ARM64` matrix. That meant KEVM was compiled four times per release (twice per architecture), doubling build pressure for no benefit: nix is content-addressed, so once `.#kevm` is realized in the local store, both the `cachix push` (public `k-framework`) and `kup publish` (private `k-framework-binary`) steps just push the already-built paths.

This merges the two into a single `nix-cache` job that builds once per architecture and populates both caches, each with its own auth token.
  
**Changes:**
- Merge `nix-binary-cache` into `nix-cache`: the `kup publish k-framework-binary` step now runs as a third step after the public-cache push, sharing the single `nix build`.
- Per-step `CACHIX_AUTH_TOKEN` preserved (public `CACHIX_PUBLIC_TOKEN` for the `k-framework` push, private `CACHIX_PRIVATE_KFB_TOKEN` for the `k-framework-binary` publish).
- Drop `nix-binary-cache` from `make-release`'s `needs` (now `[draft-release, nix-cache]`).
- Single failure-handling pair (delete drafted release + Slack notification) now covers all push steps.
  
🤖 Generated with [Claude Code](https://claude.com/claude-code)
