### PR TITLE
evm-semantics/evm.md: rewrite #transferFunds rule to be linear

### DIFF
--- a/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
+++ b/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/evm.md
@@ -1080,13 +1080,14 @@ These are just used by the other operators for shuffling local execution state a
     syntax InternalOp ::= "#transferFunds" Int Int Int
                         | "#transferFundsToNonExistent" Int Int Int
  // ---------------------------------------------------------------
-    rule <k> #transferFunds ACCT ACCT VALUE => .K ... </k>
+    rule <k> #transferFunds ACCTFROM ACCTTO VALUE => .K ... </k>
          <account>
-           <acctID> ACCT </acctID>
+           <acctID> ACCTFROM </acctID>
            <balance> ORIGFROM </balance>
            ...
          </account>
-      requires VALUE <=Int ORIGFROM
+      requires ACCTFROM ==K ACCTTO
+       andBool VALUE <=Int ORIGFROM
 
     rule <k> #transferFunds ACCTFROM ACCTTO VALUE => .K ... </k>
          <account>


### PR DESCRIPTION
The same-account variant of #transferFunds was

```
    rule <k> #transferFunds ACCT ACCT VALUE => .K ... </k>
         ...
      requires VALUE <=Int ORIGFROM
```

i.e. the linearity guard `ACCT ACCT` required the two account-id arguments to be syntactically identical. Booster's matcher cannot discharge that on distinct-named symbolic variables (e.g. `#transferFunds ?CONTRACT_ID 1 0`), even when the path constraint implies their distinctness — match returns Indeterminate, booster aborts, and the proof yields to kore.

Reformulate as

```
    rule <k> #transferFunds ACCTFROM ACCTTO VALUE => .K ... </k>
         ...
      requires ACCTFROM ==K ACCTTO andBool VALUE <=Int ORIGFROM
```

The LHS now uses distinct variable names so the match is unconditional; the original linearity moves into the side condition as `==K`, which booster can discharge via the path constraint (or via its SMT path) without an indeterminate-match abort. Semantically equivalent on concrete inputs and strictly more permissive on symbolic inputs in a sound direction (matches when args are semantically equal but not syntactically).

Recover-mode sweep identified 12 kore-execute handoffs (all benchmarks ecrecover variants) caused by this exact match-fail abort. Validated locally on benchmarks/ecrecover00-siginvalid-spec.k.