### PR TITLE
.github/with-docker: make compatible with podman as well

### DIFF
--- a/.github/actions/with-docker/action.yml
+++ b/.github/actions/with-docker/action.yml
@@ -29,8 +29,8 @@ runs:
     run: |
       set -euxo pipefail
 
-      USER=github-user
-      GROUP=${USER}
+      IMAGE_USER=github-user
+      IMAGE_GROUP=${IMAGE_USER}
       Z3_VERSION=$(cat deps/z3)
       K_VERSION=$(cat deps/k_release)
       UV_VERSION=$(cat deps/uv_release)
@@ -41,8 +41,8 @@ runs:
         --tag "${TAG_NAME}"                         \
         --build-arg USER_ID="${USER_ID}"            \
         --build-arg GROUP_ID="${GROUP_ID}"          \
-        --build-arg USER="${USER}"                  \
-        --build-arg GROUP="${GROUP}"                \
+        --build-arg IMAGE_USER="${IMAGE_USER}"                  \
+        --build-arg IMAGE_GROUP="${IMAGE_GROUP}"                \
         --build-arg K_VERSION="${K_VERSION}"        \
         --build-arg Z3_VERSION="${Z3_VERSION}"      \
         --build-arg LLVM_VERSION="${LLVM_VERSION}"  \
@@ -55,8 +55,8 @@ runs:
         --tty                               \
         --detach                            \
         --user root                         \
-        --workdir "/home/${USER}/workspace" \
+        --workdir "/home/${IMAGE_USER}/workspace" \
         "${TAG_NAME}"
 
-      docker cp ./. "${CONTAINER_NAME}":"/home/${USER}/workspace"
-      docker exec "${CONTAINER_NAME}" chown -R "${USER}:${GROUP}" "/home/${USER}"
+      docker cp ./. "${CONTAINER_NAME}":"/home/${IMAGE_USER}/workspace"
+      docker exec "${CONTAINER_NAME}" chown -R "${IMAGE_USER}:${IMAGE_GROUP}" "/home/${IMAGE_USER}"

--- a/.github/actions/with-docker/action.yml
+++ b/.github/actions/with-docker/action.yml
@@ -58,5 +58,5 @@ runs:
         --workdir "/home/${USER}/workspace" \
         "${TAG_NAME}"
 
-      docker cp . "${CONTAINER_NAME}":"/home/${USER}/workspace"
+      docker cp ./. "${CONTAINER_NAME}":"/home/${USER}/workspace"
       docker exec "${CONTAINER_NAME}" chown -R "${USER}:${GROUP}" "/home/${USER}"

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -30,17 +30,17 @@ RUN    apt-get update                  \
             python3                    \
             python3-pip
 
-ARG USER=user
-ARG GROUP
+ARG IMAGE_USER=user
+ARG IMAGE_GROUP
 ARG USER_ID
 ARG GROUP_ID
-RUN groupadd -g ${GROUP_ID} ${GROUP} && useradd -m -u ${USER_ID} -s /bin/sh -g ${GROUP} ${USER}
+RUN groupadd -g ${GROUP_ID} ${IMAGE_GROUP} && useradd -m -u ${USER_ID} -s /bin/sh -g ${IMAGE_GROUP} ${IMAGE_USER}
 
-USER ${USER}:${GROUP}
-RUN mkdir /home/${USER}/workspace
-WORKDIR /home/${USER}/workspace
+USER ${IMAGE_USER}:${IMAGE_GROUP}
+RUN mkdir /home/${IMAGE_USER}/workspace
+WORKDIR /home/${IMAGE_USER}/workspace
 
-ENV PATH=/home/${USER}/.local/bin:${PATH}
+ENV PATH=/home/${IMAGE_USER}/.local/bin:${PATH}
 
 ARG UV_VERSION
 RUN    curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh \

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -3,12 +3,12 @@ ARG K_VERSION
 ARG LLVM_VERSION
 
 ARG Z3_VERSION
-FROM runtimeverificationinc/z3:ubuntu-jammy-${Z3_VERSION} as Z3
+FROM runtimeverificationinc/z3:ubuntu-jammy-${Z3_VERSION} AS z3
 
 ARG K_VERSION
 FROM runtimeverificationinc/kframework-k:ubuntu-jammy-${K_VERSION}
 
-COPY --from=Z3 /usr/bin/z3 /usr/bin/z3
+COPY --from=z3 /usr/bin/z3 /usr/bin/z3
 
 ARG LLVM_VERSION
 


### PR DESCRIPTION
`docker cp . ...` behaves differently on `docker` backend and `podman` backend, this enables it to work the same on both. Also the variable `USER` and `GROUP` being used in the docker scripts is clobbering the login-set variants of those variables that all shells are given, so those variable names are changed. It happened to work before because `github-user` matched the name we were using for teh user on the lxc containers.