### PR TITLE
Fix CI container name collision on podman runners

### DIFF
--- a/.github/actions/with-docker/action.yml
+++ b/.github/actions/with-docker/action.yml
@@ -48,6 +48,8 @@ runs:
         --build-arg LLVM_VERSION="${LLVM_VERSION}"  \
         --build-arg UV_VERSION="${UV_VERSION}"
 
+      docker rm -f "${CONTAINER_NAME}" || true
+
       docker run                            \
         --name "${CONTAINER_NAME}"          \
         --rm                                \

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -107,9 +107,7 @@ jobs:
       - name: 'Tear down Docker'
         if: always()
         run: |
-          # Best effort: the container does not exist if 'Set up Docker' failed, and a
-          # non-zero exit here would mask the step that actually failed.
-          docker stop --timeout=0 kevm-ci-concrete-${{ github.sha }} || true
+          docker rm -f kevm-ci-concrete-${{ github.sha }} || true
 
   test-prove:
     name: 'Proofs: ${{ matrix.name }}'
@@ -170,9 +168,7 @@ jobs:
       - name: 'Tear down Docker'
         if: always()
         run: |
-          # Best effort: the container does not exist if 'Set up Docker' failed, and a
-          # non-zero exit here would mask the step that actually failed.
-          docker stop --timeout=0 kevm-ci-haskell-${{ matrix.test-suite }}-${{ github.sha }} || true
+          docker rm -f kevm-ci-haskell-${{ matrix.test-suite }}-${{ github.sha }} || true
 
   nix:
     name: 'Nix'


### PR DESCRIPTION
CI has been failing intermittently with `creating container storage: the container name "kevm-ci-haskell-<suite>-<sha>" is already in use`, most recently in the [DSS job](https://github.com/runtimeverification/evm-semantics/actions/runs/34429692352/job/102819958894).

The container name only embeds the merge SHA. On the podman-based self-hosted runners, when a job is canceled (e.g., the DSS suite hitting its 45-minute timeout), the teardown's `docker stop` reports success, but removing a `--rm` container is not part of `stop` itself. 

Per [podman-container-cleanup(1)](https://docs.podman.io/en/latest/markdown/podman-container-cleanup.1.html), the cleanup _"is automatically executed when containers are run in daemon mode by the conmon process when the container exits"_, and it is that cleanup's `--rm` option that, _"after cleanup, remove[s] the container entirely"_.

The runner's end-of-job orphan-process sweep kills `conmon` before that happens, so the container stays registered as running and is never removed. Every re-run of the same commit on that runner then collides with it, and `docker stop` on the ghost fails with `refusing to clean up: container state improper`.

**Changes:**
- `.github/actions/with-docker/action.yml`: force-remove any existing container with the target name before `docker run`, making container setup idempotent across retries regardless of why the previous container survived. Per [podman-rm(1)](https://docs.podman.io/en/latest/markdown/podman-rm.1.html#force-f), `--force` "also removes containers from container storage even if the container is not known to Podman" and "can be used to remove unusable containers", which covers the ghost state left behind.

- `.github/workflows/test-pr.yml`: tear down with `docker rm -f` instead of `docker stop --timeout=0`, so removal happens synchronously inside the step rather than depending on conmon's asynchronous `--rm` cleanup surviving the end of the job.